### PR TITLE
Fixed typos in various sections

### DIFF
--- a/get-started/capture-traffic.md
+++ b/get-started/capture-traffic.md
@@ -20,7 +20,7 @@ Capturing traffic with Fiddler Everywhere is as easy as executing two steps:
 
 That's it! Your incoming and outgoing traffic will be immediately captured and displayed in the [Live Traffic]({%slug web-sessions-list%}).
 
->tip With **Live Traffic** turned on to **Capturing**, open a browser like Google Chrome and type an address (like `http://example.com`). Return to Fiddler Everywhere and you will immediatly notice that the request is intercepted and the Live Traffic is populated. The **Result** field for that test address should return **200**. Your first request is now successfully captured with Fiddler!
+>tip With **Live Traffic** turned on to **Capturing**, open a browser like Google Chrome and type an address (like `http://example.com`). Return to Fiddler Everywhere and you will immediately notice that the request is intercepted and the Live Traffic is populated. The **Result** field for that test address should return **200**. Your first request is now successfully captured with Fiddler!
 
 ## Additional Resources
 

--- a/get-started/collaboration.md
+++ b/get-started/collaboration.md
@@ -52,7 +52,7 @@ Add a custom comment to one or more captured sessions to provide additional cont
 
 ![Add a comment for selected sessions](../images/livetraffic/websessions/add-session-comment.png)
 
-The newly added comment will appear in [the **Commments** column]({%slug web-sessions-list%}#live-traffic-list).
+The newly added comment will appear in [the **Comments** column]({%slug web-sessions-list%}#live-traffic-list).
 
 ### Add Notes
 

--- a/get-started/configuration.md
+++ b/get-started/configuration.md
@@ -10,7 +10,7 @@ position: 30
 
 In this article we'll discuss about how to configure Fiddler Everywhere in your system. 
 
-By default, the Fiddler Everywhere client intercepts insecure traffic (**HTTP**) only and needs an account with administrative rights to capture secure traffic (**HTTPS**). The Fiddler Everywhere client acts as a man-in-the-middle (against the HTTPS traffic). To enable capturing and decrypting HTTPS traffic, you will need to explicitly install a root trust certificate via the __HTTPS__ submenu in __Settings__.
+By default, the Fiddler Everywhere client intercepts insecure traffic (**HTTP**) only and needs an account with administrative rights to capture secure traffic (**HTTPS**). The Fiddler Everywhere client acts as a man-in-the-middle (against the HTTPS traffic). To enable capturing and decrypting HTTPS traffic, you will need to explicitly install a root trust certificate via the __HTTPS__ sub-menu in __Settings__.
 
 ## Configure on macOS
 
@@ -60,13 +60,13 @@ Some Linux distributions are using different security features and different way
 
 2. Go to __Settings > HTTPS__
 
-3. Expand the __Advanced Settings__ submenu
+3. Expand the __Advanced Settings__ sub-menu
 
 4. Click the __Export Root Certificate to Desktop__ button.
 
     ![Export root certificate](../images/settings/settings-export-cert.png)
 
-5. Import and trust the exported certificate. To be able to install the FE certificate, you need to follow some additonal steps on Linux:
+5. Import and trust the exported certificate. To be able to install the FE certificate, you need to follow some additional steps on Linux:
 
     - Create a directory and copy the certificate (exported in the previous steps). The last command will start the tool to upgrade the certificates. 
 
@@ -76,7 +76,7 @@ Some Linux distributions are using different security features and different way
 
         ![Add new certificate](../images/configuration/cert_ubunto_002.png)
 
-    - Choose the FiddlerRootCertficate.crt and press **OK**
+    - Choose the FiddlerRootCertificate.crt and press **OK**
 
         ![Add Fiddler certificate](../images/configuration/cert_ubunto_003.png)
 
@@ -94,7 +94,7 @@ Some Linux distributions are using different security features and different way
     >important Some Linux distributions like Ubuntu will use localized paths (for example, the __Desktop__ folder is renamed with the related word used in the locale language). That might cause for __step 3__ to fail due to a missing folder named __Desktop__ with an error message of type _Could not find a part of the path ..._. Until an out-of-the-box solution is implemented, you could easily workaround this issue by creating a folder called __Desktop__ at your root directory (`mkdir ~/Desktop`) and then export the certificate to the newly-created directory. Once the certificate is installed, you could safely remove the directory.
 
 
-For more information about Fiddler Everyehere settings, visit [**_Settings_**]({%slug decrypt-https-traffic%}) page.
+For more information about Fiddler Everywhere settings, visit [**_Settings_**]({%slug decrypt-https-traffic%}) page.
 
 ## Additional Resources
 

--- a/get-started/installation-procedure.md
+++ b/get-started/installation-procedure.md
@@ -10,7 +10,7 @@ position: 10
 
 Fiddler Everywhere being a cross-platform web debugging proxy allows you to inspect network traffic and debug it. It is available for Windows, macOS and Linux. In this page, we'll discuss about the system required to run Fiddler Everywhere.
 
-## System Requirments
+## System Requirements
 
 Fiddler Everywhere utilizes built-in .NET Core (cross-platform version .NET framework).
 
@@ -70,15 +70,15 @@ Steps to install Fiddler Everywhere client on your system (macOS, Windows, or Li
 
         **Gnome**
 
-        ![Gnome setting executible](../images/installation/exec-gnome.jpg)
+        ![Gnome setting executable](../images/installation/exec-gnome.jpg)
 
         **Cinnamon**
 
-        ![Cinnamon setting executible](../images/installation/exec-cinnamon.jpg)
+        ![Cinnamon setting executable](../images/installation/exec-cinnamon.jpg)
 
         **KDE**
 
-        ![KDE setting executible](../images/installation/exec-kde.jpg)
+        ![KDE setting executable](../images/installation/exec-kde.jpg)
 
 ## Create an Account
 

--- a/knowledge-base/how-to-install-fiddler-root-certificate-on-mac-os.md
+++ b/knowledge-base/how-to-install-fiddler-root-certificate-on-mac-os.md
@@ -11,11 +11,11 @@ res_type: kb
 ## Description
 How to install Fiddler root certificate on Mac OS.
 
->tip Fiddler Everywhere provides automatic option to install the root trust certtificate (administrative account still needed). Use [this documentation section]({%slug decrypt-https-traffic%}) as a reference and use the method below only if you need to add the certificate manually.
+>tip Fiddler Everywhere provides automatic option to install the root trust certificate (administrative account still needed). Use [this documentation section]({%slug decrypt-https-traffic%}) as a reference and use the method below only if you need to add the certificate manually.
 
 ## Solution
 1. Go to your __Desktop__ and click on __FiddlerRootCertificate.crt__.
 2. In __Keychain Access__ click on __DO_NOT_TRUST_FiddlerRoot__ certificate to open the __Trust dialog__
-3. Choose __Always Trust__ in the __When using this certiciate__ dropdown.
+3. Choose __Always Trust__ in the __When using this certificate__ dropdown.
 
 __Fiddler root certificate is now installed.__

--- a/knowledge-base/how-to-install-fiddler-root-certificate-on-windows.md
+++ b/knowledge-base/how-to-install-fiddler-root-certificate-on-windows.md
@@ -11,7 +11,7 @@ res_type: kb
 ## Description
 How to install Fiddler root certificate on Windows
 
->tip Fiddler Everywhere provides automatic option to install the root trust certtificate (administrative account still needed). Use [this documentation section]({%slug decrypt-https-traffic%}) as a reference and use the method below only if you need to add the certificate manually.
+>tip Fiddler Everywhere provides automatic option to install the root trust certificate (administrative account still needed). Use [this documentation section]({%slug decrypt-https-traffic%}) as a reference and use the method below only if you need to add the certificate manually.
 
 ## Solution
 1. Go to your __Desktop__ and double click on __FiddlerRootCertificate.crt__.

--- a/user-guide/file-menu.md
+++ b/user-guide/file-menu.md
@@ -18,7 +18,7 @@ The **Load Archive** command allows you to reload previously-captured traffic st
 
 ### Save Archive
 
-The **Save Archive** submenu exposes options that allow you to save traffic to SAZ files. You can save all current sessions or just the selected sessions. 
+The **Save Archive** sub-menu exposes options that allow you to save traffic to SAZ files. You can save all current sessions or just the selected sessions. 
 
 After selecting an option, a **Save** prompt will appear. The dialog provides options to use encryption (AES256) to create a password-protected archive.
 
@@ -30,7 +30,7 @@ The **Import Sessions** command allows you to import previously-captured traffic
 
 ### Export Sessions
 
-The **Export Sessions** submenu exposes options to export traffic in various file formats. You can export all current sessions or just the selected sessions. 
+The **Export Sessions** sub-menu exposes options to export traffic in various file formats. You can export all current sessions or just the selected sessions. 
 
 After selecting an option, a **Choose Format** prompt will appear. The supported formats are as follows:
 - WCAT Script
@@ -54,11 +54,11 @@ The **Check For Updates** command contacts a web service to determine whether th
 
 ### Forums
 
-The **Forums** command opens a new browser tab with the link to the Fiddler Evevywhere forums portal
+The **Forums** command opens a new browser tab with the link to the Fiddler Everywhere forums portal
 
 ### Documentation
 
-The **Documentation** command opens a new browser tab with the link to the Fiddler Evevywhere documentation website
+The **Documentation** command opens a new browser tab with the link to the Fiddler Everywhere documentation website
 
 ### Contact Support
 

--- a/user-guide/live-traffic/autoresponder.md
+++ b/user-guide/live-traffic/autoresponder.md
@@ -134,7 +134,7 @@ www.example.com/Path1/query=example.jpg // (MATCH)
 ```HTML
 regex:+.(jpg|gif|bmp)$
 
-www.example.com/Path1/query=foo.jpg&bar // (No Match - imnproper ending)
+www.example.com/Path1/query=foo.jpg&bar // (No Match - improper ending)
 www.example.com/Path1/query=exam ple.jpg // (MATCH)
 www.example.com/Path1/query=foo.JPG // (No Match - mismatched case)
 www.example.com/Path1/query=somegif.gif // (MATCH)
@@ -151,7 +151,7 @@ Beyond simply returning files, the __AutoResponder__ can perform some specific a
 | __http://targetURL__ | Returns the content of the __targetURL__ as the response. | Final |
 | __*redir:http://targetURL__ | Returns a HTTP Redirect to the target URL. Unlike the simple URL rule, this ensures that the client knows where its request is going so proper cookies are sent, etc. | Final |
 | __*bpu__ | Breaks on request before hitting the server. | Non-final|
-| __*delay:###__ | Delay sending request to the server by __###__ of miliseconds. | Non-final |
+| __*delay:###__ | Delay sending request to the server by __###__ of milliseconds. | Non-final |
 | __*header:Name=Value__ | Set the Request header with the given __Name__ to the specified __Value__. If no header of that name exists, a new header will be created. | Non-final |
 | __*flag:Name=Value__ | Set the Session Flag, with the given __Name__ to the specified __Value__. If no header of that name exists, a new header will be created. | Non-final |
 | __*CORSPreflightAllow__ | Returns a response that indicates that CORS is allowed. | Final |

--- a/user-guide/live-traffic/live-traffic.md
+++ b/user-guide/live-traffic/live-traffic.md
@@ -33,7 +33,7 @@ By default, Fiddler Everywhere uses __buffering mode__, which means that the res
     Streaming mode is useful for low-level network timing scenarios (for example, by design some browsers will parse partially-downloaded HTML, and that would start downloading external resources in parallel before the remote server has finished delivering the content).
     ![Buffering mode vs Streaming Mode](../../images/livetraffic/websessions/websessions-toolbar-streaming-mode.png)
 
-    Streaming mode is also useful in cases where a site delivers audo or video streams. These kind of never-ending streams can't be buffered by Fiddler Everywhere.
+    Streaming mode is also useful in cases where a site delivers audio or video streams. These kind of never-ending streams can't be buffered by Fiddler Everywhere.
 
 ### Decode
 
@@ -63,7 +63,7 @@ Use __Filter__ to apply advanced filters based on the Request and Response heade
 
 ### Save
 
-Use __Save__ buttton to save sessions for later use or to prepare sessions for sharing.
+Use __Save__ button to save sessions for later use or to prepare sessions for sharing.
 
 1. Click on the __Save__ button.
 
@@ -77,7 +77,7 @@ Use __Save__ buttton to save sessions for later use or to prepare sessions for s
 
 ### Share
 
-Sharing sessions greatly improves colaboration and Fiddler Everywhere provides several options to export and share sessions:
+Sharing sessions greatly improves collaboration and Fiddler Everywhere provides several options to export and share sessions:
 
 - Sharing [via __Share__ button from the __Live Traffic__ list toolbar](#share-live-traffic-sessions).
 - Sharing [via __Share__ button from the toolbar of already saved session (in __Saved Sessions__)](#share-previosly-saved-sessions).
@@ -94,20 +94,20 @@ The toolbar comes with __Share__ button that will save the currently displayed s
 1. Click on the __Share__ button.
 2. The __Save Session__ prompt window appears. You need to save the sessions before they could be shared.
 
-    ![Saving before traffic coulod be shared](../../images/livetraffic/websessions/websessions-toolbar-share-saveprompt.png)
+    ![Saving before traffic could be shared](../../images/livetraffic/websessions/websessions-toolbar-share-saveprompt.png)
 
 3. The __Share Sessions__ prompt window appears. Enter a valid email (mandatory) and notes (optional) and click on __Share__ button.
 
     ![Share prompt window](../../images/livetraffic/websessions/websessions-toolbar-share-shareprompt.png)
 
 
-To share Previosly Saved Sessions
+To share Previously Saved Sessions
 
 1. Double-click on the saved sessions entry from __Sessions__ list.
 
 2. The selected entry opens in a new tab. Click on the __Share__ button.
 
-    ![Loading previosly saved sessions](../../images/livetraffic/websessions/websessions-toolbar-share-savedshare.png)
+    ![Loading previously saved sessions](../../images/livetraffic/websessions/websessions-toolbar-share-savedshare.png)
 
 3. The __Share Sessions__ prompt window appears. Enter a valid email (mandatory) and notes (optional) and click on __Share__ button.
 
@@ -151,7 +151,7 @@ The context menu for the Live Traffic exposes several actions that can be applie
 
 ### Edit in Composer
 
-The context menu option __Edit in Composer__ loads the selected recust into the composer windows where it can be editted and reissued.
+The context menu option __Edit in Composer__ loads the selected request into the composer windows where it can be edited and reissued.
 
 ### Save
 
@@ -221,7 +221,7 @@ Use the __Select__ context menu option to select sessions that are directly rela
 
 - __Parent request__ Selects the session that is a parent of the currently selected session. Keyboard shortcut: __P__
 - __Children requests__ Selects the sessions that are children of the currently selected session. Keyboard shortcut: __C__
-- __Duplicaterequest__ Selects the session that is a duplicate to the currently selected session. Keyboard shortcut: __D__
+- __Duplicate request__ Selects the session that is a duplicate to the currently selected session. Keyboard shortcut: __D__
 
 ### Copy
 

--- a/user-guide/sessions-list.md
+++ b/user-guide/sessions-list.md
@@ -44,7 +44,7 @@ The option will load the selected session in the __Live Traffic__ list. Keyboard
 
 ### Export
 
-The option promts the __Export__ windows. The session can be exported in SAZ format which can be encrypted (optional). Keyboard shortcut: __Cmd__ + __E__ (Mac), __Ctrl__ + __E__ (Windows).
+The option prompts the __Export__ windows. The session can be exported in SAZ format which can be encrypted (optional). Keyboard shortcut: __Cmd__ + __E__ (Mac), __Ctrl__ + __E__ (Windows).
 
 ### Rename
 
@@ -52,7 +52,7 @@ The option allows you to rename the selected session. Available only for the ses
 
 ### Share
 
-The option promts a window where you could add user emails that you want to share the session with. Available only for the session owner. Keyboard shortcut: __Cmd__ + __Shift__ + __=__ (Mac), __Ctrl__ + __Shift__ + __=__ (Windows).
+The option prompts a window where you could add user emails that you want to share the session with. Available only for the session owner. Keyboard shortcut: __Cmd__ + __Shift__ + __=__ (Mac), __Ctrl__ + __Shift__ + __=__ (Windows).
 
 ### Delete
 

--- a/user-guide/settings/connections.md
+++ b/user-guide/settings/connections.md
@@ -18,7 +18,7 @@ The __Fiddler listens on port__ option controls which port Fiddler Everywhere us
 
 ### Act as a System Proxy on Startup
 
-The __Act as a system proxy on startup__ option whether or not Fiddler Everywhere registers as the system proxy during startup. Some browsers and many applications use the system proxy by default and re notified when it changes.
+The __Act as a system proxy on startup__ option whether or not Fiddler Everywhere registers as the system proxy during startup. Some browsers and many applications use the system proxy by default and are notified when it changes.
 
 ### Allow Remote Computers to Connect
 

--- a/user-guide/settings/gateway.md
+++ b/user-guide/settings/gateway.md
@@ -8,7 +8,7 @@ position: 30
 
 # Gateway
 
-The __Gateway__ submenu provide options to easily configure how Fiddler Everywhere accesses the network. By default, Fiddler Everywhere "chains" to the system's default proxy. These settings allows you to overwrite that behavior.
+The __Gateway__ sub-menu provides options to easily configure how Fiddler Everywhere accesses the network. By default, Fiddler Everywhere "chains" to the system's default proxy. These settings allows you to overwrite that behavior.
 
 ![Example manual proxy configuration](../../images/settings/gateway-system-proxy.png)
 

--- a/user-guide/settings/https.md
+++ b/user-guide/settings/https.md
@@ -8,7 +8,7 @@ position: 10
 
 # HTTPS Settings
 
-After the initial startup, the Fiddler Everywhere application could only capture non-secure traffic (HTTP) while SSL traffic is not captured. To enable capturing and decrypting HTTPS traffic, you will need to explicitly install a root trust certificate via the __HTTPS__ submenu in __Settings__.
+After the initial startup, the Fiddler Everywhere application could only capture non-secure traffic (HTTP) while SSL traffic is not captured. To enable capturing and decrypting HTTPS traffic, you will need to explicitly install a root trust certificate via the __HTTPS__ sub-menu in __Settings__.
 
 ![default https settings](../../images/settings/settings-https.png)
 

--- a/user-guide/settings/privacy.md
+++ b/user-guide/settings/privacy.md
@@ -8,18 +8,18 @@ position: 40
 
 # Privacy
 
-The __Privacy__ submenu contains options to opt-out of receiving emails from Progress and its partners and the opportunity to request the deletion of your Fiddler Everywhere associated account.
+The __Privacy__ sub-menu contains options to opt-out of receiving emails from Progress and its partners and the opportunity to request the deletion of your Fiddler Everywhere associated account.
 
 ![Privacy settings](../../images/settings/privacy-all.png)
 
 ### Unsubscribe from emails
 
-To submit a request to unsubscribe from receiving future emails, click on the __Unsibscribe__ link. You will be redirected to a unsubscribe page where you should follow the given instructions.
+To submit a request to unsubscribe from receiving future emails, click on the __Unsubscribe__ link. You will be redirected to a unsubscribe page where you should follow the given instructions.
 
 ### Delete your Fiddler Account
 
-To submit a request to click on the __Submut "Delete Account" request__ link. You will be redirected to a page where you should follow the given instructions.
+To submit a request, click on the __Submit "Delete Account" request__ link. You will be redirected to a page where you should follow the given instructions.
 
 ### Send anonymous usage statistics
 
-Check/uncheck the __Send anonymous usage statistics__ option depending on whether you want to send anonymous usage statistics. Once the choice is made, click on __Save Changes__ to apply then change.
+Check/uncheck the __Send anonymous usage statistics__ option depending on whether you want to send anonymous usage statistics. Once the choice is made, click on __Save Changes__ to apply the change.


### PR DESCRIPTION
There were some minor errors in typing in the following sections:

- User Guide > Live Traffic > Live Traffic
- User Guide > Live Traffic > AutoResponder
- User Guide > File Menu
- User Guide > Sessions List
- User Guide > Settings > Gateway
- User Guide > Settings > HTTPS
- User Guide > Settings > Privacy
- User Guide > Settings > Connections
- Get Started > Capture Traffic
- Get Started > Collaboration
- Get Started > Configuration
- Get Started > Installation

And some minor fixes in articles for the knowledge base section.

This pull request aims to fix all those typos. Each file was separately committed with its changes for better dx (Except for knowledge base due to long file names). All the commits can be squashed together. 😄
