### PR TITLE
configuration.md: Replace picture with text

### DIFF
--- a/get-started/configuration.md
+++ b/get-started/configuration.md
@@ -70,7 +70,11 @@ Some Linux distributions are using different security features and different way
 
     - Create a directory and copy the certificate (exported in the previous steps). The last command will start the tool to upgrade the certificates. 
 
-        ![Make dir and copy certificate](../images/configuration/cert_ubunto_001.png)
+        ```shell
+        $ sudo mkdir /usr/share/ca-certificates/extra
+        $ sudo cp ~/Desktop/FiddlerRootCertificate.crt /usr/share/ca-certificates/extra
+        $ sudo dpkg-reconfigure ca-certificates
+        ```
 
     - From the prompt select **Yes** to install new certificates
 


### PR DESCRIPTION
It is said "a picture is worth a thousand words", but in this case, a few words are more useful. Especially for things like this, where the user should be able to copy-paste the instructions to their own terminal, it makes things much easier.