### PR TITLE
chore: update what's new for 2.0.2

### DIFF
--- a/release-notes/whats-new.json
+++ b/release-notes/whats-new.json
@@ -1,5 +1,20 @@
 [
     {
+        "version": "2.0.2",
+        "items": [
+            {
+                "title": "Introducing the New Rule Builder",
+                "description": "Build your own Rules out of the box, mark sessions, test web changes quickly, and make the process of debugging and development easier using the new Rule Builder in Fiddler Everywhere.",
+                "url": "https://www.telerik.com/blogs/introducing-new-rule-builder-fiddler-everywhere"
+            },
+            {
+                "title": "Fiddler Everywhere 2.0 Is Here!",
+                "description": "Fiddler Everywhere 2.0 is here and it comes with UI enhancements and new, more powerful features! Plus take a sneak peek of what else we are preparing to introduce next in Fiddler Everywhere in 2021.",
+                "url": "https://www.telerik.com/blogs/new-release-fiddler-everywhere-2.0"
+            }
+        ]
+    },
+    {
         "version": "1.4.1",
         "items": [
             {


### PR DESCRIPTION
Update the what's new section for 2.0.2 with new blog posts - for the rule builder and for the 2.0 release.

![Screenshot 2021-07-29 at 9 23 40](https://user-images.githubusercontent.com/8351653/127443762-0f211f36-6fba-4f47-a05a-e7017b76f702.png)
![Screenshot 2021-07-29 at 9 23 48](https://user-images.githubusercontent.com/8351653/127443757-8bf42115-31d4-4a95-8393-495c358c3d92.png)