### PR TITLE
chore: update whats new for 3.0 release

### DIFF
--- a/release-notes/release-notes-insiders.json
+++ b/release-notes/release-notes-insiders.json
@@ -8,7 +8,7 @@
                 "type": "New",
                 "entries": [
                     {
-                        "title": "HTTP/2 Support (currently in Beta, you need to enable it in Settings) "
+                        "title": "HTTP/2 Support (currently in Beta, you need to enable it in Settings)"
                     },
                     {
                         "title": "Inspection of WebSocket communication"
@@ -41,7 +41,7 @@
                         "title": "Added support for decoding of Bzip2 content encoding"
                     },
                     {
-                        "title": "Updated the application build dependencies to use .NET 6.0 and Electron 15.0. "
+                        "title": "Updated the application build dependencies to use .NET 6.0 and Electron 15.0"
                     }
                 ]
             },

--- a/release-notes/release-notes.json
+++ b/release-notes/release-notes.json
@@ -8,7 +8,7 @@
                 "type": "New",
                 "entries": [
                     {
-                        "title": "HTTP/2 Support (currently in Beta, you need to enable it in Settings) "
+                        "title": "HTTP/2 Support (currently in Beta, you need to enable it in Settings)"
                     },
                     {
                         "title": "Inspection of WebSocket communication"
@@ -41,7 +41,7 @@
                         "title": "Added support for decoding of Bzip2 content encoding"
                     },
                     {
-                        "title": "Updated the application build dependencies to use .NET 6.0 and Electron 15.0. "
+                        "title": "Updated the application build dependencies to use .NET 6.0 and Electron 15.0"
                     }
                 ]
             },

--- a/release-notes/whats-new.json
+++ b/release-notes/whats-new.json
@@ -1,5 +1,25 @@
 [
     {
+        "version": "3.0.0",
+        "items": [
+            {
+                "title": "Fiddler Everywhere 3.0 Is Here!",
+                "description": "Fiddler Everywhere 3.0 release comes with long-awaited features such as HTTP/2, WebSocket support, new Advanced Filters and more!",
+                "url": "https://www.telerik.com/blogs/new-release-fiddler-everywhere-3"
+            },
+            {
+                "title": "Introducing Preconfigured Browser Capturing in Fiddler Everywhere",
+                "description": "One can now capture HTTP(S) traffic without the need to trust Fiddler's root certificate and change the system proxy.",
+                "url": "https://www.telerik.com/blogs/introducing-preconfigured-browser-capturing-fiddler-everywhere"
+            },
+            {
+                "title": "Introducing the New Rule Builder",
+                "description": "Build your own Rules out of the box, mark sessions, test web changes quickly, and make the process of debugging and development easier using the new Rule Builder in Fiddler Everywhere.",
+                "url": "https://www.telerik.com/blogs/introducing-new-rule-builder-fiddler-everywhere"
+            }
+        ]
+    },
+    {
         "version": "2.2.0",
         "items": [
             {


### PR DESCRIPTION
Update the What's new section for 3.0 release - add the new blog post and remove the one for 2.0 release.
Also, remove 2 incorrect spaces from the release notes