### PR TITLE
docs: note about installation scope on Windows

### DIFF
--- a/get-started/quickstart-windows.md
+++ b/get-started/quickstart-windows.md
@@ -38,6 +38,8 @@ You'll first have to install the latest version of Fiddler Everywhere on your ma
 1. Run the **Fiddler Everywhere** exe file to go through the installation process.
 
 
+>tip Fiddler Everywhere for Windows offers you the flexibility to select the installation scope based on your preferences. You can opt for a per user installation, limiting access to the currently logged-in user, or choose a per machine installation, allowing all users on the host machine to utilize Fiddler Everywhere. Note that simultaneous execution of multiple instances of Fiddler Everywhere on the same host machine is not supported.
+
 ## Step 2: Create Your Fiddler Account
 
 In this step you'll register by creating your unified Telerik account and become a trial user.   

--- a/get-started/quickstart-windows.md
+++ b/get-started/quickstart-windows.md
@@ -37,8 +37,9 @@ You'll first have to install the latest version of Fiddler Everywhere on your ma
 
 1. Run the **Fiddler Everywhere** exe file to go through the installation process.
 
+Fiddler Everywhere for Windows offers you the flexibility to select the installation scope based on your preferences. You can opt for a **per user** installation, limiting access to the currently logged-in user, or choose a **per machine** installation, allowing all users on the host machine to utilize Fiddler Everywhere. Note that simultaneous execution of multiple instances of Fiddler Everywhere on the same host machine is not supported.
 
->tip Fiddler Everywhere for Windows offers you the flexibility to select the installation scope based on your preferences. You can opt for a per user installation, limiting access to the currently logged-in user, or choose a per machine installation, allowing all users on the host machine to utilize Fiddler Everywhere. Note that simultaneous execution of multiple instances of Fiddler Everywhere on the same host machine is not supported.
+When Fiddler Everywhere is installed per machine, each individual user should log into Fiddler Everywhere with their own credentials and the generated data won't be accessible from the other users.
 
 ## Step 2: Create Your Fiddler Account
 

--- a/security.md
+++ b/security.md
@@ -85,6 +85,9 @@ While using Fiddler Everywhere, consider the following security indicators and h
 
 - Sessions uploaded to the Fiddler cloud space are encrypted when password protection is enabled. Unencrypted sessions are stored in the cloud as [Fiddler archives]({%slug fiddler-saz-format%}).
 
+- Fiddler Everywhere can be installed per machine on Windows OS (macOS and Linux installation is only per user). In that case,  each individual Fiddler user logs into the application with their own credentials and the generated data is be accessible from the other users.
+
+
 ## Application Analytics
 
 By default, the Fiddler Everywhere application comes with an integrated Analytics solution that collects application usage data to improve product stability, UI, and UX. The collected information is stored on an external server and does not contain any data related to the captured traffic and the data that the sessions include. You can opt out from the analytics data collection by navigating to **Settings** > **Privacy** > **Automatically send data to help us improve the product**.


### PR DESCRIPTION
Adding a note for the possibility of choosing the installation scope on Windows. We will improve the article one the feature is cross-platform and the get started section is restructured.

related to: https://kinvey.atlassian.net/browse/FID-95