### PR TITLE
docs: redirect obsolete pages

### DIFF
--- a/modify-and-filter-traffic/modify-traffic-with-rules.md
+++ b/modify-and-filter-traffic/modify-traffic-with-rules.md
@@ -4,7 +4,7 @@ description: "Modify the HTTPS sessions while using the Rules tab in Fiddler Eve
 slug: modify-traffic-get-started
 publish: true
 position: 10
-previous_url: /get-started/modify-traffic, /get-started/traffic/modify-traffic, /traffic/modify-traffic, /user-guide/rules, /get-started/mock-server-response, /mock-server-response, /knowledge-base/autoresponder, /user-guide/live-traffic/rules
+previous_url: /get-started/modify-traffic, /get-started/traffic/modify-traffic, /traffic/modify-traffic, /user-guide/rules, /get-started/mock-server-response, /mock-server-response, /knowledge-base/autoresponder, /user-guide/live-traffic/rules, /user-guide/live-traffic/rules-builder, /user-guide/live-traffic/autoresponder
 ---
 
 # Modifying Traffic


### PR DESCRIPTION
after deploy test live immediately to ensure that the redirects are working as expected.
