### PR TITLE
docs: update steps for Ubuntu 24.04

### DIFF
--- a/installation-and-setup/quickstart-linux.md
+++ b/installation-and-setup/quickstart-linux.md
@@ -41,7 +41,7 @@ Install the latest version of Fiddler Everywhere on your machine.
 
 1. Download the latest version of [Fiddler Everywhere](https://www.telerik.com/download/fiddler-everywhere).
 
-1. Install the downloaded package. On most Linux distributions, you must set the installation file as executable before starting the installation. To achieve this, either use the command line or the GUI of the desired distribution:
+1. Install the downloaded package. On most Linux distributions, you must set the installation file as executable before starting the installation. To achieve this, either use the command line or the GUI of the desired distribution. 
 
     - Setting the installation plan as executable through the command line:
 
@@ -67,6 +67,19 @@ Install the latest version of Fiddler Everywhere on your machine.
 
           ![KDE setting executable](../images/installation/exec-kde.jpg)
 
+### Ubuntu 24.04 Specifics
+
+Recent reports on Ubuntu version 24.04 showed a bug related to most Electron-based applications (like Fiddler Everywhere) where the file can not be set as executable (refer to [this GitHub thread](https://github.com/electron/electron/issues/42510)). In case you are unable to execute the Fiddler installation after the above steps, then try the following:
+
+1. Open a terminal
+
+1. Run the following command:
+ 
+  ```bash
+  sudo apt install libfuse2
+  ```
+
+The above installs the required dependencies to run .appimage files on Ubuntu 24.04. If the application does not start, try to start it from the terminal and check the output for errors. If you see an error "The SUID sandbox helper binary was found, but is not configured correctly" then you must add the `--no-sandbox` command line option when starting the application from the terminal. 
 
 ## Step 2: Create Your Fiddler Account
 


### PR DESCRIPTION
Related to https://github.com/electron/electron/issues/42510 - inability to set the appimage as executable on Ubuntu 24.04