### PR TITLE
docs: add Agent Cache MCP tools to documentation

### DIFF
--- a/agent-cache.md
+++ b/agent-cache.md
@@ -134,8 +134,6 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 ### Session Management Tools with Agent Calls Support
 
-The following session management tools support the Agent Calls tab through the `sessionsSource` parameter set to `AgentCalls`:
-
 | Tool | Description |
 |:-----|:------------|
 | `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `IsCached` (cache state), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -129,7 +129,7 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `cache_agent_calls` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (boolean — `true` to enable caching, `false` to disable it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but stops serving cached responses. |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (`enable` to start caching, `disable` to stop it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but stops serving cached responses. |
 | `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (integer — the target session ID). Returns the cache status for the requested session. |
 
 ### Session Management Tools with Agent Calls Support

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -129,8 +129,8 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `toggle_cache` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (the target session ID) and `enableCache` (`true` to enable caching, `false` to disable it). When enabled, the session's recorded response is served from cache for matching future requests. When disabled, the session remains visible but no longer serves cached responses. |
-| `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (the target session ID). Returns the current cache status for the requested session. |
+| `toggle_cache` | Toggles caching on or off for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (boolean — `true` to enable caching, `false` to disable it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. |
+| `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (integer — the target session ID). Returns the cache status for the requested session. |
 
 ### Session Management Tools with Agent Calls Support
 
@@ -138,11 +138,11 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `IsCached` (cache state), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |
+| `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `isCached` (cache state), `model` (the LLM model name), and `promptPreview` (a preview of the last user prompt). Active filters are applied if any. |
 | `get_sessions_count` | Returns the total number of sessions in the Agent Calls tab. |
-| `get_session_details` | Fetches full details for a specific session in the Agent Calls tab by its ID. |
-| `apply_filters` | Applies filter criteria to the Agent Calls tab to narrow down visible sessions. |
-| `clear_sessions` | Removes all sessions from the Agent Calls tab. If cached sessions are present, an elicitation prompts the user to confirm, as clearing also stops caching for those sessions. |
+| `get_session_details` | Fetches detailed information about a specific session in the Agent Calls tab by its ID. **Required parameter:** `sessionId` (integer). |
+| `apply_filters` | Applies filter criteria to the Agent Calls tab to narrow down visible sessions. Applying filters wipes all existing filters. To clear all filters, call this tool with an empty filter collection. |
+| `clear_sessions` | Clears all sessions from the Agent Calls tab. If cached sessions are present, a confirmation prompt warns the user, as clearing also stops caching for those sessions. |
 
 ### Example MCP Prompts for Agent Cache
 

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -129,20 +129,20 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `toggle_cache` | Toggles caching on or off for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (boolean — `true` to enable caching, `false` to disable it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (boolean — `true` to enable caching, `false` to disable it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but stops serving cached responses. |
 | `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (integer — the target session ID). Returns the cache status for the requested session. |
 
 ### Session Management Tools with Agent Calls Support
 
->tip When prompting your coding assistant, explicitly mention **"Agent Calls"** (or similar wording such as "Agent Calls tab") in your request. This tells the MCP server to target the **Agent Calls** tab. If you omit this context, the tools default to operating on the **Live Traffic** tab instead.
+>tip When prompting your coding assistant, explicitly specify **"Agent Calls"** as the sessions source in your request. The `sessionsSource` parameter is required for all session management tools. Set it to `AgentCalls` to target the **Agent Calls** tab or to `LiveTraffic` for the **Live Traffic** tab.
 
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `isCached` (cache state), `model` (the LLM model name), and `promptPreview` (a preview of the last user prompt). Active filters are applied if any. |
-| `get_sessions_count` | Returns the total number of sessions in the Agent Calls tab. |
-| `get_session_details` | Fetches detailed information about a specific session in the Agent Calls tab by its ID. **Required parameter:** `sessionId` (integer). |
-| `apply_filters` | Applies filter criteria to the Agent Calls tab to narrow down visible sessions. Applying filters wipes all existing filters. To clear all filters, call this tool with an empty filter collection. |
-| `clear_sessions` | Clears all sessions from the Agent Calls tab. If cached sessions are present, a confirmation prompt warns the user, as clearing also stops caching for those sessions. |
+| `get_sessions` | Gets sessions from the specified Fiddler sessions source. When `sessionsSource` is set to `AgentCalls`, each session includes additional Agent Cache-specific fields: `isCached` status, `model` (the LLM model name), and `promptPreview` (a preview of the last user prompt). Active filters are applied if any. **Required parameter:** `sessionsSource`. |
+| `get_sessions_count` | Gets the number of sessions in the specified Fiddler sessions source. **Required parameter:** `sessionsSource`. |
+| `get_session_details` | Gets detailed information about a specific session in the specified Fiddler sessions source. **Required parameters:** `sessionId` (integer) and `sessionsSource`. |
+| `apply_filters` | Applies filter criteria to the specified Fiddler sessions source to narrow down visible sessions. Applying filters wipes all existing filters. To clear all filters, call this tool with an empty filter collection. **Required parameters:** `filters` (object) and `sessionsSource`. |
+| `clear_sessions` | Clears all sessions in the specified Fiddler sessions source. Agent calls are also HTTP traffic so they appear in both tabs. **Required parameter:** `sessionsSource`. |
 
 ### Example MCP Prompts for Agent Cache
 

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -129,8 +129,8 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `toggle_cache` | Enables or disables caching for a specific session in the Agent Calls tab. When enabled, the session's recorded response is served from cache for matching future requests. When disabled, the session remains visible but no longer serves cached responses. |
-| `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. Returns the current cache status for the requested session. |
+| `toggle_cache` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (the target session ID) and `enableCache` (`true` to enable caching, `false` to disable it). When enabled, the session's recorded response is served from cache for matching future requests. When disabled, the session remains visible but no longer serves cached responses. |
+| `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (the target session ID). Returns the current cache status for the requested session. |
 
 ### Session Management Tools with Agent Calls Support
 

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -129,7 +129,7 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 | Tool | Description |
 |:-----|:------------|
-| `cache_agent_calls` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (`enable` to start caching, `disable` to stop it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but stops serving cached responses. |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the Agent Calls tab. **Required parameters:** `sessionId` (integer — the target session ID) and `enableCache` (boolean — `true` to enable caching, `false` to disable it). When caching is enabled, the session's response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but stops serving cached responses. |
 | `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. **Required parameter:** `sessionId` (integer — the target session ID). Returns the cache status for the requested session. |
 
 ### Session Management Tools with Agent Calls Support

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -134,6 +134,8 @@ The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated
 
 ### Session Management Tools with Agent Calls Support
 
+>tip When prompting your coding assistant, explicitly mention **"Agent Calls"** (or similar wording such as "Agent Calls tab") in your request. This tells the MCP server to target the **Agent Calls** tab. If you omit this context, the tools default to operating on the **Live Traffic** tab instead.
+
 | Tool | Description |
 |:-----|:------------|
 | `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `IsCached` (cache state), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -121,6 +121,51 @@ The following diagram shows the request flow when Agent Cache is active.
 3. When the **Caching** switch is enabled for that session, Fiddler replays the stored response for any matching subsequent call.
 4. The provider endpoint never receives the duplicate request—no tokens are charged.
 
+## MCP Tools for Agent Cache
+
+The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated tools for programmatic interaction with Agent Cache directly from your AI-powered coding assistant. These tools allow you to manage cached sessions, check cache status, and toggle caching without leaving your IDE.
+
+### Dedicated Agent Cache Tools
+
+| Tool | Description |
+|:-----|:------------|
+| `toggle_cache` | Enables or disables caching for a specific session in the Agent Calls tab. When enabled, the session's recorded response is served from cache for matching future requests. When disabled, the session remains visible but no longer serves cached responses. |
+| `check_cache_status` | Checks whether a specific session in the Agent Calls tab is currently cached. Returns the current cache status for the requested session. |
+
+### Session Management Tools with Agent Calls Support
+
+The following session management tools support the Agent Calls tab through the `sessionsSource` parameter set to `AgentCalls`:
+
+| Tool | Description |
+|:-----|:------------|
+| `get_sessions` | Retrieves sessions from the Agent Calls tab. Returns additional Agent Cache-specific fields: `IsCached` (cache state), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |
+| `get_sessions_count` | Returns the total number of sessions in the Agent Calls tab. |
+| `get_session_details` | Fetches full details for a specific session in the Agent Calls tab by its ID. |
+| `apply_filters` | Applies filter criteria to the Agent Calls tab to narrow down visible sessions. |
+| `clear_sessions` | Removes all sessions from the Agent Calls tab. If cached sessions are present, an elicitation prompts the user to confirm, as clearing also stops caching for those sessions. |
+
+### Example MCP Prompts for Agent Cache
+
+Use these prompts with your coding assistant to interact with Agent Cache through the MCP server:
+
+```txt
+#fiddler Check the cache status of session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Enable caching for session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Show me all sessions in the Agent Calls tab
+```
+
+```txt
+#fiddler How many sessions are currently in the Agent Calls tab?
+```
+
+For the full list of available prompts, refer to the [Prompt Library](slug://fiddler_ai_prompt_library).
+
 ## Notes
 
 - Agent Cache is available on Trial, Pro, and Enterprise plans. It is not available on Lite licenses.

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -272,11 +272,11 @@ The session management tools support both the **Live Traffic** and **Agent Calls
 
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Retrieves the list of captured HTTP/HTTPS sessions from the selected sessions source, optionally limited by any active filters. Returns session metadata such as URLs, methods, status codes, and timing. When the `sessionsSource` is set to `AgentCalls`, each session also includes `IsCached` (whether the session response is cached), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |
+| `get_sessions` | Retrieves the list of captured HTTP/HTTPS sessions from the selected sessions source. Active filters are applied if any. Returns session metadata such as URLs, methods, status codes, and timing. When `sessionsSource` is set to `AgentCalls`, each session also includes `isCached` (whether the session response is cached), `model` (the LLM model name), and `promptPreview` (a preview of the last user prompt). |
 | `get_sessions_count` | Returns the total number of sessions in the selected sessions source. Useful for quickly assessing session volume without fetching the full session list. |
-| `get_session_details` | Fetches full details for a specific captured session by its ID from the selected sessions source, including request and response headers, request and response body, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. |
-| `apply_filters` | Applies filter criteria (such as URL pattern, status code, or HTTP method) to the selected sessions source to narrow down the sessions visible to subsequent tool calls. |
-| `clear_sessions` | Permanently removes all sessions from the selected sessions source. When clearing the Agent Calls tab with cached sessions present, an elicitation prompts the user to confirm, as clearing also stops caching for those sessions. |
+| `get_session_details` | Fetches detailed information about a specific captured session by its ID from the selected sessions source, including request and response headers, bodies, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. **Required parameter:** `sessionId` (integer). The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. |
+| `apply_filters` | Applies filter criteria (such as URL pattern, status code, or HTTP method) to the selected sessions source to narrow down the sessions visible to subsequent tool calls. Applying filters wipes all existing filters. To clear all active filters, call this tool with an empty filter collection. |
+| `clear_sessions` | Clears all sessions from the selected sessions source. When clearing the Agent Calls tab with cached sessions present, a confirmation prompt warns the user, as clearing also stops caching for those sessions. |
 
 ### Agent Cache
 
@@ -284,8 +284,8 @@ The Agent Cache tools provide programmatic control over the [Agent Cache](slug:/
 
 | Tool | Description |
 |:-----|:------------|
-| `toggle_cache` | Enables or disables caching for a specific session in the **Agent Calls** tab. When caching is enabled for a session, its recorded response is served from cache for all matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. Requires a `sessionId` and an `enableCache` boolean parameter. |
-| `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. Requires a `sessionId` parameter. |
+| `toggle_cache` | Toggles caching on or off for a specific session in the **Agent Calls** tab. When caching is enabled for a session, its response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (boolean). |
+| `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. **Required parameter:** `sessionId` (integer). |
 
 ### Rules
 

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -268,13 +268,24 @@ The Fiddler Everywhere MCP server exposes the following tools. These tools can b
 
 ### Session Management
 
+The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a `sessionsSource` parameter. The parameter accepts the values `LiveTraffic` (default) and `AgentCalls`. When omitted, the tools operate on the Live Traffic tab.
+
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Retrieves the list of captured HTTP/HTTPS sessions, optionally limited by any active filters. Returns session metadata such as URLs, methods, status codes, and timing. |
-| `get_sessions_count` | Returns the total number of currently captured sessions. Useful for quickly assessing session volume without fetching the full session list. |
-| `get_session_details` | Fetches full details for a specific captured session by its ID, including request and response headers, request and response body, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. The session ID is the numeric value shown in the **ID** column of the **Live Traffic** grid in Fiddler Everywhere. |
-| `apply_filters` | Applies filter criteria (such as URL pattern, status code, or HTTP method) to the active session list to narrow down the sessions visible to subsequent tool calls. |
-| `clear_sessions` | Permanently removes all currently captured sessions from the Fiddler Everywhere session list. |
+| `get_sessions` | Retrieves the list of captured HTTP/HTTPS sessions from the selected sessions source, optionally limited by any active filters. Returns session metadata such as URLs, methods, status codes, and timing. When the `sessionsSource` is set to `AgentCalls`, each session also includes `IsCached` (whether the session response is cached), `Model` (the LLM model used), and `PromptPreview` (a preview of the last user prompt, limited to 200 characters). |
+| `get_sessions_count` | Returns the total number of sessions in the selected sessions source. Useful for quickly assessing session volume without fetching the full session list. |
+| `get_session_details` | Fetches full details for a specific captured session by its ID from the selected sessions source, including request and response headers, request and response body, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. |
+| `apply_filters` | Applies filter criteria (such as URL pattern, status code, or HTTP method) to the selected sessions source to narrow down the sessions visible to subsequent tool calls. |
+| `clear_sessions` | Permanently removes all sessions from the selected sessions source. When clearing the Agent Calls tab with cached sessions present, an elicitation prompts the user to confirm, as clearing also stops caching for those sessions. |
+
+### Agent Cache
+
+The Agent Cache tools provide programmatic control over the [Agent Cache](slug://agent-cache) functionality, allowing you to manage cached responses for model-provider endpoint sessions directly from your coding assistant.
+
+| Tool | Description |
+|:-----|:------------|
+| `toggle_cache` | Enables or disables caching for a specific session in the **Agent Calls** tab. When caching is enabled for a session, its recorded response is served from cache for all matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. Requires a `sessionId` and an `enableCache` boolean parameter. |
+| `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. Requires a `sessionId` parameter. |
 
 ### Rules
 

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -284,7 +284,7 @@ The Agent Cache tools provide programmatic control over the [Agent Cache](slug:/
 
 | Tool | Description |
 |:-----|:------------|
-| `cache_agent_calls` | Enables or disables caching for a specific session in the **Agent Calls** tab. Set `enableCache` to `enable` to cache the session—future requests matching this session will be served from cache instead of hitting the server. Set `enableCache` to `disable` to stop caching—the session remains in the Agent Calls tab but stops serving cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (`enable` or `disable`). |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the **Agent Calls** tab. Set `enableCache` to `true` to cache the session—future requests matching this session will be served from cache instead of hitting the server. Set `enableCache` to `false` to disable caching—the session remains in the Agent Calls tab but stops serving cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (boolean). |
 | `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. **Required parameter:** `sessionId` (integer). |
 
 ### Rules

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -268,7 +268,7 @@ The Fiddler Everywhere MCP server exposes the following tools. These tools can b
 
 ### Session Management
 
-The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a `sessionsSource` parameter. The parameter accepts the values `LiveTraffic` (default) and `AgentCalls`. When omitted, the tools operate on the Live Traffic tab.
+The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. The default value is `LiveTraffic`—when the sessions source is not explicitly mentioned in your prompt, the tools automatically operate on the **Live Traffic** tab. To target the **Agent Calls** tab instead, explicitly include "Agent Calls" (or similar wording) in your prompt so that the coding assistant sets `sessionsSource` to `AgentCalls`.
 
 | Tool | Description |
 |:-----|:------------|

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -284,7 +284,7 @@ The Agent Cache tools provide programmatic control over the [Agent Cache](slug:/
 
 | Tool | Description |
 |:-----|:------------|
-| `cache_agent_calls` | Enables or disables caching for a specific session in the **Agent Calls** tab. Set `enableCache` to `true` to cache the session—future requests matching this session will be served from cache instead of hitting the server. Set `enableCache` to `false` to disable caching—the session remains in the Agent Calls tab but stops serving cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (boolean). |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the **Agent Calls** tab. Set `enableCache` to `enable` to cache the session—future requests matching this session will be served from cache instead of hitting the server. Set `enableCache` to `disable` to stop caching—the session remains in the Agent Calls tab but stops serving cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (`enable` or `disable`). |
 | `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. **Required parameter:** `sessionId` (integer). |
 
 ### Rules

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -254,29 +254,29 @@ The Fiddler Everywhere MCP server exposes the following tools. These tools can b
 
 | Tool | Description |
 |:-----|:------------|
-| `get_status` | Returns the current status of the Fiddler Everywhere application, including login state, certificate trust status, proxy configuration, and captured session counts. Useful as a health check before issuing other commands. |
-| `is_user_logged_in` | Checks whether the current user is authenticated with Fiddler Everywhere. Returns a boolean result. |
-| `initiate_login` | Triggers the Fiddler Everywhere login flow by opening the authentication page. Use this when `is_user_logged_in` reports that the user is not authenticated. |
-| `open_trust_root_certificate_dialog` | Opens the Fiddler Everywhere dialog for trusting the root CA certificate. Trusting the certificate is required for HTTPS traffic decryption and interception. |
+| `get_status` | Gets the current status of Fiddler, including `IsUserLoggedIn`, `IsRootCertificateTrusted`, number of Browser and Terminal instances running, reverse proxy status and configured ports, `IsSystemProxyEnabled`, `IsNetworkCaptureEnabled`, and the number of captured and visible sessions. Useful as a health check before issuing other commands. |
+| `is_user_logged_in` | Indicates whether Fiddler is currently authenticated. |
+| `initiate_login` | Performs login to Fiddler. Opens a new Chrome window for authentication. Use this when `is_user_logged_in` reports that the user is not authenticated. |
+| `open_trust_root_certificate_dialog` | Opens the system trust root certificate dialog. Required for HTTPS traffic interception. |
 
 ### Traffic Capture
 
 | Tool | Description |
 |:-----|:------------|
-| `start_capture_with_browser` | Launches a browser instance (Chrome) with the Fiddler Everywhere proxy settings pre-configured, enabling immediate capture of browser HTTP/HTTPS traffic. |
-| `start_capture_with_terminal` | Opens a terminal session with the Fiddler Everywhere proxy environment variables pre-set, enabling capture of traffic from CLI tools, scripts, or applications started within that terminal. |
+| `start_capture_with_browser` | Opens a fresh Chrome-based browser instance with Fiddler proxy settings applied. |
+| `start_capture_with_terminal` | Starts a new terminal with Fiddler proxy settings applied. |
 
 ### Session Management
 
-The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. The default value is `LiveTraffic`—when the sessions source is not explicitly mentioned in your prompt, the tools automatically operate on the **Live Traffic** tab. To target the **Agent Calls** tab instead, explicitly include "Agent Calls" (or similar wording) in your prompt so that the coding assistant sets `sessionsSource` to `AgentCalls`.
+The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a required `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls. When prompting your coding assistant, explicitly specify which sessions source to target so that the `sessionsSource` parameter is set correctly.
 
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Retrieves the list of captured HTTP/HTTPS sessions from the selected sessions source. Active filters are applied if any. Returns session metadata such as URLs, methods, status codes, and timing. When `sessionsSource` is set to `AgentCalls`, each session also includes `isCached` (whether the session response is cached), `model` (the LLM model name), and `promptPreview` (a preview of the last user prompt). |
-| `get_sessions_count` | Returns the total number of sessions in the selected sessions source. Useful for quickly assessing session volume without fetching the full session list. |
-| `get_session_details` | Fetches detailed information about a specific captured session by its ID from the selected sessions source, including request and response headers, bodies, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. **Required parameter:** `sessionId` (integer). The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. |
-| `apply_filters` | Applies filter criteria (such as URL pattern, status code, or HTTP method) to the selected sessions source to narrow down the sessions visible to subsequent tool calls. Applying filters wipes all existing filters. To clear all active filters, call this tool with an empty filter collection. |
-| `clear_sessions` | Clears all sessions from the selected sessions source. When clearing the Agent Calls tab with cached sessions present, a confirmation prompt warns the user, as clearing also stops caching for those sessions. |
+| `get_sessions` | Gets the sessions from the specified Fiddler sessions source. Active filters are applied if any. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls—each session also includes `isCached` status, the LLM model name, and a preview of the last user prompt. **Required parameter:** `sessionsSource`. |
+| `get_sessions_count` | Gets the number of sessions in the specified Fiddler sessions source. **Required parameter:** `sessionsSource`. |
+| `get_session_details` | Gets detailed information about a specific session in the specified Fiddler sessions source, including request and response headers, bodies, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. **Required parameters:** `sessionId` (integer) and `sessionsSource`. |
+| `apply_filters` | Applies filters to the specified Fiddler sessions source. Selects only the sessions that match the specified criteria. Applying filters wipes all existing filters. To clear filters, call this tool with an empty filter collection. **Required parameters:** `filters` (object) and `sessionsSource`. |
+| `clear_sessions` | Clears all sessions in the specified Fiddler sessions source. Agent calls are also HTTP traffic so they appear in both tabs. **Required parameter:** `sessionsSource`. |
 
 ### Agent Cache
 
@@ -284,24 +284,24 @@ The Agent Cache tools provide programmatic control over the [Agent Cache](slug:/
 
 | Tool | Description |
 |:-----|:------------|
-| `toggle_cache` | Toggles caching on or off for a specific session in the **Agent Calls** tab. When caching is enabled for a session, its response is served from cache for matching future requests. When caching is disabled, the session remains in the Agent Calls tab but no longer serves cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (boolean). |
+| `cache_agent_calls` | Enables or disables caching for a specific session in the **Agent Calls** tab. Set `enableCache` to `true` to cache the session—future requests matching this session will be served from cache instead of hitting the server. Set `enableCache` to `false` to disable caching—the session remains in the Agent Calls tab but stops serving cached responses. **Required parameters:** `sessionId` (integer) and `enableCache` (boolean). |
 | `check_cache_status` | Checks whether a specific session in the **Agent Calls** tab is currently cached. Returns the cache status for the requested session. **Required parameter:** `sessionId` (integer). |
 
 ### Rules
 
 | Tool | Description |
 |:-----|:------------|
-| `create_rule` | Creates a traffic manipulation rule with configurable match conditions and actions. Rules can be used to modify request or response headers, redirect URLs, inject content, simulate latency, and more. |
-| `clear_rules` | Removes all rules that were created through the MCP server during the current session. |
+| `create_rule` | Creates a rule to modify sessions in Fiddler. The rule is applied to all sessions that match the specified criteria. At least one condition must be specified. If the match criteria requires response data, it is matched after the server responds; otherwise before the request is sent. If an action updates response data (such as the status code), it executes after the response is received; other actions are applied before the request is sent. If an action is marked as final, no other actions are executed after it. Some actions are final even if not explicitly marked—`CloseGracefully`, `CloseNonGracefully`, `DoNotShow`, and `DoNotDecrypt`. These four do not require any additional parameters except for the type. Update actions need parameters: all require a `condition` and a `value`, and if the action updates a header, also a `key`. |
+| `clear_rules` | Clears all rules created from the MCP server. |
 
 ### Reverse Proxy
 
 | Tool | Description |
 |:-----|:------------|
-| `add_reverse_proxy_port` | Adds a reverse proxy mapping that forwards traffic arriving on a specified local port to a designated remote host and port. Useful for intercepting traffic from applications that do not honor system proxy settings. |
-| `remove_reverse_proxy_port` | Removes a previously configured reverse proxy port mapping by its local port number. |
-| `enable_reverse_proxy` | Enables the Fiddler Everywhere reverse proxy feature so that active port mappings start forwarding traffic. |
-| `disable_reverse_proxy` | Disables the Fiddler Everywhere reverse proxy feature, stopping all active port mappings from forwarding traffic. |
+| `add_reverse_proxy_port` | Adds a reverse proxy configuration to Fiddler to forward requests from a specific port to a remote host and intercept the traffic in between. Useful for testing and debugging purposes. **Required parameters:** `clientPort` (integer — the local port to listen on) and `remoteHost` (string — the remote host to forward traffic to). |
+| `remove_reverse_proxy_port` | Removes a reverse proxy configuration for a specific port from Fiddler. **Required parameter:** `clientPort` (integer). |
+| `enable_reverse_proxy` | Enables the reverse proxy. |
+| `disable_reverse_proxy` | Disables the reverse proxy. |
 
 ## MCP Output Sanitization
 

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -121,7 +121,7 @@ Clears all sessions in the Agent Calls tab. If cached sessions are present, prom
 ```bash
 /mcp.fiddler.toggle-agent-calls-cache
 ```
-Toggles caching on or off for a specific session in the Agent Calls tab. You will be prompted to provide the session ID.
+Toggles caching on or off for a specific session in the Agent Calls tab. You will be prompted to provide the session ID and whether to enable or disable caching.
 
 ```bash
 /mcp.fiddler.check-agent-calls-cache-status

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -116,12 +116,12 @@ Fetches detailed information about a specific session in the Agent Calls tab. Yo
 ```bash
 /mcp.fiddler.clear-agent-calls-sessions
 ```
-Clears all sessions in the Agent Calls tab. If cached sessions are present, prompts for confirmation before proceeding.
+Clears all sessions in the Agent Calls tab. Agent calls are also HTTP traffic so they appear in both tabs.
 
 ```bash
-/mcp.fiddler.toggle-agent-calls-cache
+/mcp.fiddler.cache-agent-calls
 ```
-Toggles caching on or off for a specific session in the Agent Calls tab. You will be prompted to provide the session ID and whether to enable or disable caching.
+Enables or disables caching for a specific session in the Agent Calls tab. You will be prompted to provide the session ID and whether to enable or disable caching.
 
 ```bash
 /mcp.fiddler.check-agent-calls-cache-status

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -96,6 +96,38 @@ Fetches detailed information about a specific session. You will be prompted to p
 ```
 Clears all currently captured sessions from Fiddler Everywhere.
 
+#### Agent Cache
+
+```bash
+/mcp.fiddler.get-agent-cache-sessions-count
+```
+Returns the total number of sessions in the Agent Calls tab in Fiddler Everywhere.
+
+```bash
+/mcp.fiddler.get-agent-cache-sessions
+```
+Retrieves the sessions in the Agent Calls tab, including cache status, model information, and prompt previews.
+
+```bash
+/mcp.fiddler.get-agent-cache-session-details
+```
+Fetches detailed information about a specific session in the Agent Calls tab. You will be prompted to provide the session ID.
+
+```bash
+/mcp.fiddler.clear-agent-cache-sessions
+```
+Clears all sessions in the Agent Calls tab. If cached sessions are present, prompts for confirmation before proceeding.
+
+```bash
+/mcp.fiddler.toggle-agent-cache
+```
+Toggles caching on or off for a specific session in the Agent Calls tab. You will be prompted to provide the session ID.
+
+```bash
+/mcp.fiddler.check-agent-cache-status
+```
+Checks whether a specific session in the Agent Calls tab is currently cached. You will be prompted to provide the session ID.
+
 #### Reverse Proxy Operations
 
 ```bash
@@ -173,6 +205,46 @@ Start capturing traffic and manage your sessions with these essential prompts:
 
 ```txt
 #fiddler Clear all captured sessions
+```
+
+### Agent Cache
+
+Manage cached agent sessions and control caching behavior through the Agent Calls tab:
+
+```txt
+#fiddler Show me all sessions in the Agent Calls tab
+```
+
+```txt
+#fiddler How many sessions are currently in the Agent Calls tab?
+```
+
+```txt
+#fiddler Get detailed information about session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Enable caching for session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Disable caching for session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Check the cache status of session {sessionId} in the Agent Calls tab
+```
+
+```txt
+#fiddler Clear all sessions in the Agent Calls tab
+```
+
+```txt
+#fiddler Show me all cached sessions in the Agent Calls tab
+```
+
+```txt
+#fiddler Which model was used for session {sessionId} in the Agent Calls tab?
 ```
 
 ### Traffic Analysis

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -96,35 +96,35 @@ Fetches detailed information about a specific session. You will be prompted to p
 ```
 Clears all currently captured sessions from Fiddler Everywhere.
 
-#### Agent Cache
+#### Agent Calls
 
 ```bash
-/mcp.fiddler.get-agent-cache-sessions-count
+/mcp.fiddler.get-agent-calls-sessions-count
 ```
 Returns the total number of sessions in the Agent Calls tab in Fiddler Everywhere.
 
 ```bash
-/mcp.fiddler.get-agent-cache-sessions
+/mcp.fiddler.get-agent-calls-sessions
 ```
 Retrieves the sessions in the Agent Calls tab, including cache status, model information, and prompt previews.
 
 ```bash
-/mcp.fiddler.get-agent-cache-session-details
+/mcp.fiddler.get-agent-calls-session-details
 ```
 Fetches detailed information about a specific session in the Agent Calls tab. You will be prompted to provide the session ID.
 
 ```bash
-/mcp.fiddler.clear-agent-cache-sessions
+/mcp.fiddler.clear-agent-calls-sessions
 ```
 Clears all sessions in the Agent Calls tab. If cached sessions are present, prompts for confirmation before proceeding.
 
 ```bash
-/mcp.fiddler.toggle-agent-cache
+/mcp.fiddler.toggle-agent-calls-cache
 ```
 Toggles caching on or off for a specific session in the Agent Calls tab. You will be prompted to provide the session ID.
 
 ```bash
-/mcp.fiddler.check-agent-cache-status
+/mcp.fiddler.check-agent-calls-cache-status
 ```
 Checks whether a specific session in the Agent Calls tab is currently cached. You will be prompted to provide the session ID.
 


### PR DESCRIPTION
- Update fiddler-mcp-server.md: add sessionsSource parameter to session management tools, add new Agent Cache tools section (toggle_cache, check_cache_status)
- Update agent-cache.md: add MCP Tools for Agent Cache section with dedicated tools, adapted session tools, and example prompts
- Update prompt-library.md: add built-in Agent Cache prompts and custom prompt examples

related to https://kinvey.atlassian.net/browse/FID-8294