### PR TITLE
[FID-8553] docs: Add Agent Inspector documentation and update HTTP Inspector naming

### DIFF
--- a/agent-cache.md
+++ b/agent-cache.md
@@ -40,6 +40,8 @@ The grid adds one dedicated sticky column:
 
 When the **Caching** switch is enabled for a session, Fiddler Everywhere intercepts matching outbound calls and returns the cached response instead of forwarding the request to the remote endpoint. When the switch is disabled, requests pass through normally.
 
+Selecting any session in the **Agent Calls** tab opens the [**Agent Inspector**](slug://inspector-types#agent-inspector) in the details pane. The Agent Inspector provides structured, AI-specific analysis of the selected session across five sub-tabs: **Cost** (token usage and monetary cost, including cache savings), **Latency** (response time and cache-avoided latency), **Messages** (the full user/agent conversation), **Tools** (any tool calls made during the session), and **Model** (provider, model version, and system prompt).
+
 ## Get Started
 
 The following scenario demonstrates how Agent Cache eliminates redundant token usage during the development of an agent that calls a model-provider endpoint.
@@ -50,6 +52,7 @@ The following scenario demonstrates how Agent Cache eliminates redundant token u
 1. Run your agent to trigger an HTTPS call to the model-provider endpoint.
 1. Open **Traffic** > **Agent Calls**.
 1. Locate the captured session in the grid (use the **Host** or **URL** columns to identify it).
+1. Select the session to open the [**Agent Inspector**](slug://inspector-types#agent-inspector) in the details pane—review the **Cost**, **Latency**, **Messages**, **Tools**, and **Model** sub-tabs to confirm the captured response meets your expectations before caching it.
 1. Enable the **Caching** switch for that session in the sticky **Caching** column.
        ![The "Agent Calls" tab in Fiddler](./images/caching-column.png)
 1. Run your agent again with the same request.
@@ -183,6 +186,7 @@ We welcome your feedback on Agent Cache and any other features you would like to
 
 ## See Also
 
+* [Agent Inspector](slug://inspector-types#agent-inspector)
 * [the Fiddler MCP Server - Overview](slug://fiddler-mcp-server)
 * [the Fiddler MCP Server - Prompt Ideas](slug://fiddler_ai_prompt_library)
 * [the Fiddler Debugging Assistant](slug://fiddler-assistant)

--- a/agent-cache.md
+++ b/agent-cache.md
@@ -40,7 +40,7 @@ The grid adds one dedicated sticky column:
 
 When the **Caching** switch is enabled for a session, Fiddler Everywhere intercepts matching outbound calls and returns the cached response instead of forwarding the request to the remote endpoint. When the switch is disabled, requests pass through normally.
 
-Selecting any session in the **Agent Calls** tab opens the [**Agent Inspector**](slug://inspector-types#agent-inspector) in the details pane. The Agent Inspector provides structured, AI-specific analysis of the selected session across five sub-tabs: **Cost** (token usage and monetary cost, including cache savings), **Latency** (response time and cache-avoided latency), **Messages** (the full user/agent conversation), **Tools** (any tool calls made during the session), and **Model** (provider, model version, and system prompt).
+Selecting any session in the **Agent Calls** tab opens the [**Agent Inspector**](slug://inspector-types#agent-inspector) in the details pane. The Agent Inspector provides structured analysis of the selected session across five sub-tabs: **Cost** (token usage and monetary cost, including cache savings), **Latency** (response time and cache-avoided latency), **Messages** (the full user/agent conversation), **Tools** (all available tools and any tool calls made during the session), and **Model** (provider, model version, and system prompt).
 
 ## Get Started
 
@@ -126,7 +126,7 @@ The following diagram shows the request flow when Agent Cache is active.
 
 ## MCP Tools for Agent Cache
 
-The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated tools for programmatic interaction with Agent Cache directly from your AI-powered coding assistant. These tools allow you to manage cached sessions, check cache status, and toggle caching without leaving your IDE.
+The [Fiddler Everywhere MCP server](slug://fiddler-mcp-server) exposes dedicated tools for programmatic interaction with Agent Cache directly from your coding assistant. These tools allow you to manage cached sessions, check cache status, and toggle caching without leaving your IDE.
 
 ### Dedicated Agent Cache Tools
 

--- a/agent-tools/agent-skills.md
+++ b/agent-tools/agent-skills.md
@@ -173,7 +173,7 @@ Each skill below includes its purpose, the steps it performs, and example trigge
 
 ### fiddler-traffic-debugging
 
-**Purpose**: Analyzes the HTTPS traffic captured by Fiddler Everywhere after you run a feature or user flow, and produces a structured debugging report grouped by endpoint — flagging failures, auth errors, retries, performance issues, and slow calls.
+**Purpose**: Analyzes the HTTPS traffic captured by Fiddler Everywhere after you run a feature or user flow, and produces a structured debugging report grouped by endpoint — flagging failures, auth errors, retries, performance issues, and slow calls. For AI/LLM sessions captured in the **Agent Calls** tab, the corresponding data (cost, latency, messages, tool calls, and model configuration) is also available in the Fiddler Everywhere UI through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab.
 
 **What it does**:
 1. Calls `get_status` to confirm Fiddler is reachable and capturing.

--- a/agent-tools/agent-skills.md
+++ b/agent-tools/agent-skills.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Skills
-page_title: Fiddler Everywhere Agent Skills – Automate MCP Setup and Traffic Analysis in AI Coding Tools
-description: "Install and use the official Fiddler Everywhere agent skills to automate MCP server configuration, HTTPS traffic analysis, and Fiddler installation in AI-powered IDEs such as GitHub Copilot, Claude Code, Cursor, Windsurf, and OpenAI Codex CLI."
+page_title: Fiddler Everywhere Agent Skills – Automate MCP Setup and Traffic Analysis in LLM-Powered Coding Tools
+description: "Install and use the official Fiddler Everywhere agent skills to automate MCP server configuration, HTTPS traffic analysis, and Fiddler installation in LLM-powered IDEs such as GitHub Copilot, Claude Code, Cursor, Windsurf, and OpenAI Codex CLI."
 slug: fiddler-agent-skills
 publish: true
 position: 15
@@ -173,7 +173,7 @@ Each skill below includes its purpose, the steps it performs, and example trigge
 
 ### fiddler-traffic-debugging
 
-**Purpose**: Analyzes the HTTPS traffic captured by Fiddler Everywhere after you run a feature or user flow, and produces a structured debugging report grouped by endpoint — flagging failures, auth errors, retries, performance issues, and slow calls. For AI/LLM sessions captured in the **Agent Calls** tab, the corresponding data (cost, latency, messages, tool calls, and model configuration) is also available in the Fiddler Everywhere UI through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab.
+**Purpose**: Analyzes the HTTPS traffic captured by Fiddler Everywhere after you run a feature or user flow, and produces a structured debugging report grouped by endpoint — flagging failures, auth errors, retries, performance issues, and slow calls. For LLM/agent sessions captured in the **Agent Calls** tab, the corresponding data (cost, latency, messages, tool calls, and model configuration) is also available in the Fiddler Everywhere UI through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab.
 
 **What it does**:
 1. Calls `get_status` to confirm Fiddler is reachable and capturing.

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: Fiddler MCP Server
-page_title: Fiddler Everywhere MCP Server – Connect AI-Powered IDEs to Live HTTPS Traffic
-description: "Install and configure the Fiddler Everywhere MCP server to give AI-powered IDEs and LLM coding assistants (VS Code, Cursor, Claude, Windsurf) real-time access to captured HTTPS traffic for debugging, security analysis, and performance optimization."
+page_title: Fiddler Everywhere MCP Server – Connect LLM-Powered Coding Tools to Live HTTPS Traffic
+description: "Install and configure the Fiddler Everywhere MCP server to give LLM-powered coding assistants (VS Code, Cursor, Claude, Windsurf) real-time access to captured HTTPS traffic for debugging, security analysis, and performance optimization."
 slug: fiddler-mcp-server
 publish: true
 position: 1
@@ -297,13 +297,13 @@ The `capture_application` tool relies on the [network capturing mode](slug://cap
 
 ### Session Management
 
-The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a required `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls. When prompting your coding assistant, explicitly specify which sessions source to target so that the `sessionsSource` parameter is set correctly.
+The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a required `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM agent API calls. When prompting your coding assistant, explicitly specify which sessions source to target so that the `sessionsSource` parameter is set correctly.
 
->tip Sessions from the **Agent Calls** tab can also be inspected visually through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab in the Fiddler Everywhere UI. The Agent Inspector surfaces cost, latency, messages, tool calls, and model configuration in a structured view for each AI session.
+>tip Sessions from the **Agent Calls** tab can also be inspected visually through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab in the Fiddler Everywhere UI. The Agent Inspector surfaces cost, latency, messages, tool calls, and model configuration in a structured view for each agent session.
 
 | Tool | Description |
 |:-----|:------------|
-| `get_sessions` | Gets the sessions from the specified Fiddler sessions source. Active filters are applied if any. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls—each session also includes `isCached` status, the LLM model name, and a preview of the last user prompt. **Required parameter:** `sessionsSource`. |
+| `get_sessions` | Gets the sessions from the specified Fiddler sessions source. Active filters are applied if any. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM agent API calls—each session also includes `isCached` status, the LLM model name, and a preview of the last user prompt. **Required parameter:** `sessionsSource`. |
 | `get_sessions_count` | Gets the number of sessions in the specified Fiddler sessions source. **Required parameter:** `sessionsSource`. |
 | `get_session_details` | Gets detailed information about a specific session in the specified Fiddler sessions source, including request and response headers, bodies, HTTP method, URL, status code, protocol, start time, duration, client and remote HTTP versions, TLS versions, and IP addresses. The session ID is the numeric value shown in the **ID** column of the traffic grid in Fiddler Everywhere. **Required parameters:** `sessionId` (integer) and `sessionsSource`. |
 | `apply_filters` | Applies filters to the specified Fiddler sessions source. Selects only the sessions that match the specified criteria. Applying filters wipes all existing filters. To clear filters, call this tool with an empty filter collection. **Required parameters:** `filters` (object) and `sessionsSource`. |

--- a/agent-tools/fiddler-mcp-server.md
+++ b/agent-tools/fiddler-mcp-server.md
@@ -299,6 +299,8 @@ The `capture_application` tool relies on the [network capturing mode](slug://cap
 
 The session management tools support both the **Live Traffic** and **Agent Calls** tabs through a required `sessionsSource` parameter. The parameter accepts two values: `LiveTraffic` and `AgentCalls`. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls. When prompting your coding assistant, explicitly specify which sessions source to target so that the `sessionsSource` parameter is set correctly.
 
+>tip Sessions from the **Agent Calls** tab can also be inspected visually through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab in the Fiddler Everywhere UI. The Agent Inspector surfaces cost, latency, messages, tool calls, and model configuration in a structured view for each AI session.
+
 | Tool | Description |
 |:-----|:------------|
 | `get_sessions` | Gets the sessions from the specified Fiddler sessions source. Active filters are applied if any. Use `LiveTraffic` for real-time captured HTTP/HTTPS traffic. Use `AgentCalls` for LLM/AI agent API calls—each session also includes `isCached` status, the LLM model name, and a preview of the last user prompt. **Required parameter:** `sessionsSource`. |
@@ -309,7 +311,7 @@ The session management tools support both the **Live Traffic** and **Agent Calls
 
 ### Agent Cache
 
-The Agent Cache tools provide programmatic control over the [Agent Cache](slug://agent-cache) functionality, allowing you to manage cached responses for model-provider endpoint sessions directly from your coding assistant.
+The Agent Cache tools provide programmatic control over the [Agent Cache](slug://agent-cache) functionality, allowing you to manage cached responses for model-provider endpoint sessions directly from your coding assistant. The data exposed by these tools is also surfaced visually in the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab within the Fiddler Everywhere UI, where you can review cost savings, latency gains, messages, tool calls, and model configuration for each cached session.
 
 | Tool | Description |
 |:-----|:------------|

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -1,7 +1,7 @@
 ---
 title: Prompt Library
-page_title: Fiddler Everywhere AI Prompt Library – MCP Prompts for HTTP Traffic Analysis
-description: "Explore a curated library of built-in and custom AI prompts for the Fiddler Everywhere MCP server. Use LLM-powered coding assistants to analyze HTTPS traffic, detect security vulnerabilities, optimize performance, and automate debugging workflows."
+page_title: Fiddler Everywhere Prompt Library – MCP Prompts for HTTP Traffic Analysis
+description: "Explore a curated library of built-in and custom prompts for the Fiddler Everywhere MCP server. Use LLM-powered coding assistants to analyze HTTPS traffic, detect security vulnerabilities, optimize performance, and automate debugging workflows."
 slug: fiddler_ai_prompt_library
 position: 10
 previous_url: /mcp-server/prompt-library

--- a/agent-tools/prompt-library.md
+++ b/agent-tools/prompt-library.md
@@ -209,7 +209,7 @@ Start capturing traffic and manage your sessions with these essential prompts:
 
 ### Agent Cache
 
-Manage cached agent sessions and control caching behavior through the Agent Calls tab:
+Manage cached agent sessions and control caching behavior through the Agent Calls tab. The cache metadata (cost savings, latency gains, model info) is also available directly in the Fiddler Everywhere UI through the [**Agent Inspector**](slug://inspector-types#agent-inspector) tab:
 
 ```txt
 #fiddler Show me all sessions in the Agent Calls tab

--- a/capture-traffic/advanced-capturing-options/capturing-grpc-traffic.md
+++ b/capture-traffic/advanced-capturing-options/capturing-grpc-traffic.md
@@ -32,7 +32,7 @@ To capture gRPC traffic with Fiddler Everywhere, the following conditions must b
 
 ## Inspecting gRPC Traffic
 
-Fiddler Everywhere introduces a specific user interface to ease the inspection of gRPC traffic. [The gRPC inspectors](slug://inspector-types#websocket-grpc-sse-and-socketio-inspectors) are pretty similar to the inspectors used for capturing WebSocket traffic with one exception - the new gRPC Response inspector called **Trailer** (part of the **Handshake** tab). 
+Fiddler Everywhere introduces a specific user interface to ease the inspection of gRPC traffic. [The gRPC inspectors](slug://inspector-types#websocket-grpc-sse-and-socketio-inspectors) are pretty similar to the HTTP Inspector sub-inspectors used for capturing WebSocket traffic with one exception - the new gRPC Response inspector called **Trailer** (part of the **Handshake** tab). 
 
 You can use the **Trailer** inspector to examine the specific trailers the server sends or mock particular gRPC behavior. For example, you can modify (through a rule) the `grpc_status` trailer header and test how your application behaves in unexpected scenarios like unexpected errors in the stream.
 

--- a/capture-traffic/capturing-modes.md
+++ b/capture-traffic/capturing-modes.md
@@ -241,7 +241,7 @@ Streaming HTTP uses the standard HTTP protocol with chunked transfer encoding to
 
 **Fiddler Streaming HTTP Support:**
 - Compatible with all capturing modes
-- Reuses the standard [HTTP inspectors](slug://inspector-types)
+- Reuses the standard [HTTP Inspector](slug://inspector-types)
 - Automatic decoding of encoded messages
 
 ### WebSocket Protocol

--- a/inspect-traffic/inspect-traffic.md
+++ b/inspect-traffic/inspect-traffic.md
@@ -19,7 +19,7 @@ The ongoing HTTP traffic shows in the **Live Traffic grid**, which contains mult
 1. Capture HTTP(S) traffic while using your preferred [capturing mode](slug://capture-traffic-get-started).
 1. Double-click a captured session.
 
-The session content immediately loads in the Fiddler **Inspectors**. The application automatically decides which inspector is best suited to display the request and response of the double-clicked session. Alternatively, you can use a single click a session to preserve the last shown inspector.
+The session content immediately loads in the Fiddler **Inspectors**. The application automatically decides which inspector is best suited to display the request and response of the double-clicked session. Alternatively, you can use a single click a session to preserve the last shown inspector. For AI-related sessions (such as calls to LLM providers), the **Agent Inspector** tab provides dedicated analysis including token cost, latency, messages, tool calls, and model configuration.
 
 [Deep-dive into the Fiddler inspectors tab here ...](slug://inspector-types)
 

--- a/inspect-traffic/inspect-traffic.md
+++ b/inspect-traffic/inspect-traffic.md
@@ -19,7 +19,7 @@ The ongoing HTTP traffic shows in the **Live Traffic grid**, which contains mult
 1. Capture HTTP(S) traffic while using your preferred [capturing mode](slug://capture-traffic-get-started).
 1. Double-click a captured session.
 
-The session content immediately loads in the Fiddler **Inspectors**. The application automatically decides which inspector is best suited to display the request and response of the double-clicked session. Alternatively, you can use a single click a session to preserve the last shown inspector. For AI-related sessions (such as calls to LLM providers), the **Agent Inspector** tab provides dedicated analysis including token cost, latency, messages, tool calls, and model configuration.
+The session content immediately loads in the Fiddler **Inspectors**. The application automatically decides which inspector is best suited to display the request and response of the double-clicked session. Alternatively, you can use a single click a session to preserve the last shown inspector. For LLM/agent sessions (such as calls to LLM providers), the **Agent Inspector** tab provides dedicated analysis including token cost, latency, messages, tool calls, and model configuration.
 
 [Deep-dive into the Fiddler inspectors tab here ...](slug://inspector-types)
 

--- a/inspect-traffic/inspector-insights.md
+++ b/inspect-traffic/inspector-insights.md
@@ -1,7 +1,7 @@
 ---
 title: Inspectors Insights
 page_title: Inspectors Insights - Inspect Traffic | Fiddler Everywhere
-description: "Using the `Inspectors` tab in the Fiddler Everywhere web-debugging proxy application. Use the HTTP Inspector and Agent Inspector tools to analyze requests, responses, and AI agent sessions."
+description: "Using the `Inspectors` tab in the Fiddler Everywhere web-debugging proxy application. Use the HTTP Inspector and Agent Inspector tools to analyze requests, responses, and agent sessions."
 slug: inspector-types
 publish: true
 position: 10
@@ -10,7 +10,7 @@ previous_url: /user-guide/live-traffic/inspectors/request-inspector, /user-guide
 
 # Inspectors Insights
 
-The Fiddler Everywhere **Inspectors** section provides dedicated tabs for inspecting different types of captured traffic. The [**HTTP Inspector**](#http-inspector) renders the HTTP **Request** and **Response** sections, which display the information for the selected HTTP(S) sessions from the sessions grid. The [**Agent Inspector**](#agent-inspector) is a dedicated inspector for AI-related sessions that surfaces cost, latency, messages, tool calls, and model configuration details. In the case where the captured traffic uses [the WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) or [the gRPC framework](https://gRPC.io/), a dedicated [**WebSocket and gRPC inspectors**](#websocket-grpc-sse-and-socketio-inspectors) tab renders, which display the connection handshake details, messages, and each message details. For secure connections in the Live Traffic section, Fiddler Everywhere can show detailed [server certificate information](#server-certificate-details).
+The Fiddler Everywhere **Inspectors** section provides dedicated tabs for inspecting different types of captured traffic. The [**HTTP Inspector**](#http-inspector) renders the HTTP **Request** and **Response** sections, which display the information for the selected HTTP(S) sessions from the sessions grid. The [**Agent Inspector**](#agent-inspector) is a dedicated inspector for LLM/agent sessions that surfaces cost, latency, messages, tool calls, and model configuration details. In the case where the captured traffic uses [the WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) or [the gRPC framework](https://gRPC.io/), a dedicated [**WebSocket and gRPC inspectors**](#websocket-grpc-sse-and-socketio-inspectors) tab renders, which display the connection handshake details, messages, and each message details. For secure connections in the Live Traffic section, Fiddler Everywhere can show detailed [server certificate information](#server-certificate-details).
 
 The inspectors are based on the [Monaco editor](https://microsoft.github.io/monaco-editor/) and provide multiple perks, among which:
 
@@ -207,7 +207,7 @@ The **Auth** inspector obtains authorization information from the `Authorize` an
 
 ## Agent Inspector
 
-The **Agent Inspector** is a dedicated inspector for AI-related sessions. It appears alongside the **HTTP Inspector** tab and is available when inspecting sessions in the **Live Traffic** grid, the **Agent Calls** tab, and saved snapshots. When an AI-related session (such as an API call to an LLM provider) is selected from the **Agent Calls** tab, the **Agent Inspector** is shown as the default inspector. When the same session is selected from the **Live Traffic** grid, the **Agent Inspector** appears as an additional tab next to **HTTP Inspector**.
+The **Agent Inspector** is a dedicated inspector for LLM/agent sessions. It appears alongside the **HTTP Inspector** tab and is available when inspecting sessions in the **Live Traffic** grid, the **Agent Calls** tab, and saved snapshots. When an agent session (such as an API call to an LLM provider) is selected from the **Agent Calls** tab, the **Agent Inspector** is shown as the default inspector. When the same session is selected from the **Live Traffic** grid, the **Agent Inspector** appears as an additional tab next to **HTTP Inspector**.
 
 The **Agent Inspector** provides the following sub-tabs:
 
@@ -219,7 +219,7 @@ The **Agent Inspector** provides the following sub-tabs:
 
 ### Cost Sub-Tab
 
-The **Cost** sub-tab provides a token usage and cost breakdown for the selected AI session. The tab contains two collapsible sections:
+The **Cost** sub-tab provides a token usage and cost breakdown for the selected session. The tab contains two collapsible sections:
 
 - **Tokens Count**&mdash;Displays the number of input tokens, output tokens, and total tokens consumed by the request, along with each value's percentage share of the total.
 - **Cost**&mdash;Displays the monetary cost for input tokens, output tokens, and the total cost of the call, along with each value's percentage share of the total.
@@ -228,31 +228,32 @@ When a session is served from the [Fiddler Everywhere Agent Cache](slug://agent-
 
 ### Latency Sub-Tab
 
-The **Latency** sub-tab shows the response time for the selected AI session. When a session is served from the [Fiddler Everywhere Agent Cache](slug://agent-cache), the tab shows a cache-hit banner indicating how many seconds of latency were avoided by serving the cached response (for example, _"Cache hit. This call avoided ~2.88 s latency."_).
+The **Latency** sub-tab shows the response time for the selected session. When a session is served from the [Fiddler Everywhere Agent Cache](slug://agent-cache), the tab shows a cache-hit banner indicating how many seconds of latency were avoided by serving the cached response (for example, _"Cache hit. This call avoided ~2.88 s latency."_).
 
 ### Messages Sub-Tab
 
-The **Messages** sub-tab renders the full conversation exchange of the selected AI session in a readable, chat-style view. Messages are presented by role:
+The **Messages** sub-tab renders the full conversation exchange of the selected session in a readable, chat-style view. Messages are presented by role:
 
-- **User**&mdash;Displays the user prompt and any additional context or data passed to the AI model.
-- **Agent**&mdash;Displays the AI model's response to the user prompt.
+- **User**&mdash;Displays the user prompt and any additional context or data passed to the model.
+- **Agent**&mdash;Displays the model's response to the user prompt.
+- **Tool Call**&mdash;Displays a tool call made by the agent during the session.
+- **Tool Response**&mdash;Displays the response returned by the tool.
 
 A filter icon in the top-right corner of the sub-tab allows you to filter the displayed messages.
 
 ### Tools Sub-Tab
 
-The **Tools** sub-tab lists any tool calls made during the AI session. The number of detected tool calls is indicated directly in the sub-tab label (for example, **Tools (0)** when no tool calls are detected). When no tool calls are present, the tab displays the message _"No tool calls detected in this session."_
+The **Tools** sub-tab displays all tools available to the model and any tool calls made during the session. The number of detected tool calls is indicated directly in the sub-tab label (for example, **Tools (0)** when no tool calls are detected). The sub-tab provides two views:
+
+- **Usage**&mdash;Shows each available tool and the number of times it was called during the session. When no tool calls are present, the view displays the message _"No tool calls detected in this session."_
+- **JSON**&mdash;Displays the full definitions of all available tools in JSON format, including their names, descriptions, and parameters.
 
 ### Model Sub-Tab
 
-The **Model** sub-tab displays the AI model configuration details for the selected session. It provides the following collapsible sections:
+The **Model** sub-tab displays the model configuration details for the selected session. It provides the following collapsible sections:
 
-- **Model Configuration**&mdash;Shows key model parameters for the session:
-    - **Provider**&mdash;The AI service provider (for example, `OpenAI`).
-    - **Model**&mdash;The specific model version used (for example, `gpt-4.1-mini-2025-04-14`).
-    - **Stream**&mdash;Indicates whether streaming was enabled for the response (`true` or `false`).
-    - **Thinking Tokens Used**&mdash;Indicates whether extended thinking tokens were consumed during the request (`Yes` or `No`).
-- **System Prompt**&mdash;Displays the system prompt passed to the AI model for the session (for example, _"Summarize hotel options. Be helpful and confident."_).
+- **Model Configuration**&mdash;Shows model parameters for the session. The available parameters vary depending on what was included in the LLM request. Common parameters include **Provider** (the service provider, for example `OpenAI`), **Model** (the model version, for example `gpt-4.1-mini-2025-04-14`), **Stream** (whether streaming was enabled), and **Thinking Tokens Used** (whether extended thinking tokens were consumed). Additional parameters such as **Max Tokens** may appear when specified in the request.
+- **System Prompt**&mdash;Displays the system prompt passed to the model for the session (for example, _"Summarize hotel options. Be helpful and confident."_).
 
 ## WebSocket, gRPC, SSE, and SocketIO Inspectors
 

--- a/inspect-traffic/inspector-insights.md
+++ b/inspect-traffic/inspector-insights.md
@@ -1,7 +1,7 @@
 ---
 title: Inspectors Insights
 page_title: Inspectors Insights - Inspect Traffic | Fiddler Everywhere
-description: "Using the `Inspectors` tab in the Fiddler Everywhere web-debugging proxy application. Use the inspection tools to analyze requests and responses."
+description: "Using the `Inspectors` tab in the Fiddler Everywhere web-debugging proxy application. Use the HTTP Inspector and Agent Inspector tools to analyze requests, responses, and AI agent sessions."
 slug: inspector-types
 publish: true
 position: 10
@@ -10,7 +10,7 @@ previous_url: /user-guide/live-traffic/inspectors/request-inspector, /user-guide
 
 # Inspectors Insights
 
-The Fiddler Everywhere **Inspectors** tab renders the HTTP **Request** and the **Response** sections, which display the information for the selected HTTP(S) sessions from the sessions grid. In the case where the captured traffic uses [the WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) or [the gRPC framework](https://gRPC.io/), a dedicated [**WebSocket and gRPC inspectors**](#websocket-grpc-sse-and-socketio-inspectors) tab renders, which display the connection handshake details, messages, and each message details. For secure connections in the Live Traffic section, Fiddler Everywhere can show detailed [server certificate information](#server-certificate-details).
+The Fiddler Everywhere **Inspectors** section provides dedicated tabs for inspecting different types of captured traffic. The [**HTTP Inspector**](#http-inspector) renders the HTTP **Request** and **Response** sections, which display the information for the selected HTTP(S) sessions from the sessions grid. The [**Agent Inspector**](#agent-inspector) is a dedicated inspector for AI-related sessions that surfaces cost, latency, messages, tool calls, and model configuration details. In the case where the captured traffic uses [the WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) or [the gRPC framework](https://gRPC.io/), a dedicated [**WebSocket and gRPC inspectors**](#websocket-grpc-sse-and-socketio-inspectors) tab renders, which display the connection handshake details, messages, and each message details. For secure connections in the Live Traffic section, Fiddler Everywhere can show detailed [server certificate information](#server-certificate-details).
 
 The inspectors are based on the [Monaco editor](https://microsoft.github.io/monaco-editor/) and provide multiple perks, among which:
 
@@ -28,9 +28,9 @@ To load the data of a session in the **Inspectors** section, double-click an HTT
 
 To switch the loaded name of the inspector, single-click the desired inspector name&mdash;for example, __Image__ or __Raw__.
 
-## HTTP(S) Inspectors
+## HTTP Inspector
 
-The **HTTP(S) Inspectors** provide the following types of inspecting tools that enable you to examine different parts of the requests and responses:
+The **HTTP Inspector** provides the following types of inspecting tools that enable you to examine different parts of the requests and responses:
 
 * [Headers inspector](#headers-inspector)
 * [Params inspector](#params-inspector)
@@ -205,6 +205,55 @@ The **Auth** inspector obtains authorization information from the `Authorize` an
 
 ![Authentication Inspector](./images/inspectors-auth.png)
 
+## Agent Inspector
+
+The **Agent Inspector** is a dedicated inspector for AI-related sessions. It appears alongside the **HTTP Inspector** tab and is available when inspecting sessions in the **Live Traffic** grid, the **Agent Calls** tab, and saved snapshots. When an AI-related session (such as an API call to an LLM provider) is selected from the **Agent Calls** tab, the **Agent Inspector** is shown as the default inspector. When the same session is selected from the **Live Traffic** grid, the **Agent Inspector** appears as an additional tab next to **HTTP Inspector**.
+
+The **Agent Inspector** provides the following sub-tabs:
+
+* [Cost](#cost-sub-tab)
+* [Latency](#latency-sub-tab)
+* [Messages](#messages-sub-tab)
+* [Tools](#tools-sub-tab)
+* [Model](#model-sub-tab)
+
+### Cost Sub-Tab
+
+The **Cost** sub-tab provides a token usage and cost breakdown for the selected AI session. The tab contains two collapsible sections:
+
+- **Tokens Count**&mdash;Displays the number of input tokens, output tokens, and total tokens consumed by the request, along with each value's percentage share of the total.
+- **Cost**&mdash;Displays the monetary cost for input tokens, output tokens, and the total cost of the call, along with each value's percentage share of the total.
+
+When a session is served from the [Fiddler Everywhere Agent Cache](slug://agent-cache), the **Cost** sub-tab also shows a cache-hit banner indicating how many tokens and how much money the cached response saved (for example, _"Cache hit. This call saved ~$0.0003 (331 tokens)."_). In this case, a note below the banner states that the metrics shown are from the cached session.
+
+### Latency Sub-Tab
+
+The **Latency** sub-tab shows the response time for the selected AI session. When a session is served from the [Fiddler Everywhere Agent Cache](slug://agent-cache), the tab shows a cache-hit banner indicating how many seconds of latency were avoided by serving the cached response (for example, _"Cache hit. This call avoided ~2.88 s latency."_).
+
+### Messages Sub-Tab
+
+The **Messages** sub-tab renders the full conversation exchange of the selected AI session in a readable, chat-style view. Messages are presented by role:
+
+- **User**&mdash;Displays the user prompt and any additional context or data passed to the AI model.
+- **Agent**&mdash;Displays the AI model's response to the user prompt.
+
+A filter icon in the top-right corner of the sub-tab allows you to filter the displayed messages.
+
+### Tools Sub-Tab
+
+The **Tools** sub-tab lists any tool calls made during the AI session. The number of detected tool calls is indicated directly in the sub-tab label (for example, **Tools (0)** when no tool calls are detected). When no tool calls are present, the tab displays the message _"No tool calls detected in this session."_
+
+### Model Sub-Tab
+
+The **Model** sub-tab displays the AI model configuration details for the selected session. It provides the following collapsible sections:
+
+- **Model Configuration**&mdash;Shows key model parameters for the session:
+    - **Provider**&mdash;The AI service provider (for example, `OpenAI`).
+    - **Model**&mdash;The specific model version used (for example, `gpt-4.1-mini-2025-04-14`).
+    - **Stream**&mdash;Indicates whether streaming was enabled for the response (`true` or `false`).
+    - **Thinking Tokens Used**&mdash;Indicates whether extended thinking tokens were consumed during the request (`Yes` or `No`).
+- **System Prompt**&mdash;Displays the system prompt passed to the AI model for the session (for example, _"Summarize hotel options. Be helpful and confident."_).
+
 ## WebSocket, gRPC, SSE, and SocketIO Inspectors
 
 Fiddler Everywhere provides common user interface to create inspectors for visualizing WebSocket, gRPC, Server-Sent Events, and Socket.IO traffic. The inspectors provide the following types of inspecting tools that enable you to examine different parts of a connection:
@@ -327,3 +376,4 @@ The Response Inspectors for ongoing capture (the sessions in the Live Traffic gr
 - [Inspecting Traffic](slug://inspecting-traffic-get-started)
 - [Overview Insights](slug://overview-tab)
 - [Comparing Sessions](slug://fe-compare-sessions)
+- [Agent Cache](slug://agent-cache)


### PR DESCRIPTION
## Summary

Relates to: https://progresssoftware.atlassian.net/browse/FID-8553

This PR documents the **Agent Inspector** — a new dedicated inspector tab for AI/LLM sessions — and aligns the entire documentation with the renamed **HTTP Inspector** tab (previously HTTP(S) Inspectors).

---

## Changes

### New: Agent Inspector documentation

**inspect-traffic/inspector-insights.md**
- Updated front-matter description to cover both HTTP Inspector and Agent Inspector.
- Rewrote the article intro to introduce both inspectors by name with anchor links.
- Renamed the HTTP(S) Inspectors section to HTTP Inspector.
- Added a new Agent Inspector section with full documentation for all five sub-tabs:
  - **Cost** — token count (input/output/total) and monetary cost breakdown; cache-hit banner behaviour.
  - **Latency** — response time display; cache-hit banner with saved latency.
  - **Messages** — chat-style conversation view with User and Agent roles.
  - **Tools** — tool call list with the Tools (N) counter; empty-state message.
  - **Model** — Model Configuration (Provider, Model, Stream, Thinking Tokens Used) and System Prompt.
- Added Agent Cache to the See Also links.

**inspect-traffic/inspect-traffic.md**
- Extended the inspector paragraph to mention the Agent Inspector tab for AI/LLM sessions.

**agent-cache.md**
- Added an Agent Inspector paragraph in the Agent Calls Tab section explaining the five sub-tabs and their relevance to cached sessions.
- Inserted a Get Started step prompting users to review the session in the Agent Inspector before enabling caching.
- Added Agent Inspector as the first link in See Also.

### Updated: Agent Inspector cross-references in agent-tools articles

**agent-tools/fiddler-mcp-server.md**
- Added a tip in Session Management pointing to the Agent Inspector for visual inspection of Agent Calls sessions.
- Extended the Agent Cache tools section to note the same data is surfaced in the Agent Inspector UI.

**agent-tools/agent-skills.md**
- Extended the fiddler-traffic-debugging skill description to mention the Agent Inspector for AI/LLM sessions.

**agent-tools/prompt-library.md**
- Updated the Agent Cache prompts section description to reference the Agent Inspector tab.

### Fixed: Stale HTTP inspector references across the docs

**capture-traffic/capturing-modes.md**
- 'HTTP inspectors' updated to 'HTTP Inspector' (singular, updated tab name).

**capture-traffic/advanced-capturing-options/capturing-grpc-traffic.md**
- Updated prose reference to match the renamed HTTP Inspector tab.

---

## Agent Inspector availability

The **Agent Inspector** tab is available in:
- The **Live Traffic** grid (as an additional tab alongside HTTP Inspector for AI sessions)
- The **Agent Calls** tab (as the default inspector)
- Saved **Snapshots**