### PR TITLE
[FID-8659] Add SSO Setup article for Fiddler Everywhere Enterprise

### DIFF
--- a/installation-and-setup/managed-app-configuration.md
+++ b/installation-and-setup/managed-app-configuration.md
@@ -132,3 +132,4 @@ For more details on each configuration key or for troubleshooting, refer to the 
 * [Not capturing traffic due to group policy](slug://resolve-proxysettingsperuser-policy)
 * [Policies for managing access and usage of the Fiddler MCP server](slug://fiddler-mcp-server#mcp-access-policies)
 * [Policies for managing access and usage of the Fiddler Debugging Assistant](slug://fiddler-assistant#debugging-assistant-access-policies)
+* [Single Sign-On (SSO) Setup](slug://fe-sso-setup)

--- a/installation-and-setup/quickstart-linux.md
+++ b/installation-and-setup/quickstart-linux.md
@@ -68,7 +68,7 @@ In this step, you will register by creating your unified Telerik account.
 
 1. Launch the Fiddler Everywhere application. Follow the **Sign in or create an account** link.
 1. Create an account using email and password or using the **Sign in with Google** option.
-  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to [this Telerik blog post](https://www.telerik.com/blogs/sso-telerik-kendo-ui-simpler-more-secure-access-account) for detailed instructions on configuring your company-specific SSO.
+  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to the [Single Sign-On (SSO) Setup]({%slug fe-sso-setup%}) article for detailed instructions on configuring your company-specific SSO.
 1. Enter the requested information on the **Enter Your Email to Sign in or Create an Account** screen.
 1. Check your inbox, open the confirmation email, and complete your account activation.
 1. Return the Fiddler Everywhere application and choose whether to become a trial user or purchase a subscription plan by selecting either the **Start Free Trial** or the **BUY NOW** link.

--- a/installation-and-setup/quickstart-macos.md
+++ b/installation-and-setup/quickstart-macos.md
@@ -43,7 +43,7 @@ In this step, you will register by creating your unified Telerik account.
 
 1. Launch the Fiddler Everywhere application. Follow the **Sign in or create an account** link.
 1. Create an account using email and password or using the **Sign in with Google** option.
-  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to [this Telerik blog post](https://www.telerik.com/blogs/sso-telerik-kendo-ui-simpler-more-secure-access-account) for detailed instructions on configuring your company-specific SSO.
+  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to the [Single Sign-On (SSO) Setup]({%slug fe-sso-setup%}) article for detailed instructions on configuring your company-specific SSO.
 1. Enter the requested information on the **Enter Your Email to Sign in or Create an Account** screen.
 1. Check your inbox, open the confirmation email, and complete your account activation.
 1. Return the Fiddler Everywhere application and choose whether to become a trial user or purchase a subscription plan by selecting either the **Start Free Trial** or the **BUY NOW** link.

--- a/installation-and-setup/quickstart-windows.md
+++ b/installation-and-setup/quickstart-windows.md
@@ -47,7 +47,7 @@ In this step, you will register by creating your unified Telerik account.
 
 1. Launch the Fiddler Everywhere application. Follow the **Sign in or create an account** link.
 1. Create an account using email and password or using the **Sign in with Google** option.
-  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to [this Telerik blog post](https://www.telerik.com/blogs/sso-telerik-kendo-ui-simpler-more-secure-access-account) for detailed instructions on configuring your company-specific SSO.
+  >tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) supports SSO login. Refer to the [Single Sign-On (SSO) Setup]({%slug fe-sso-setup%}) article for detailed instructions on configuring your company-specific SSO.
 1. Enter the requested profile information in the Telerik form.
 1. Check your inbox, open the confirmation email, and complete your account activation.
 1. Return the Fiddler Everywhere application and choose whether to become a trial user or purchase a subscription plan by selecting either the **Start Free Trial** or the **BUY NOW** link.

--- a/installation-and-setup/sso-setup.md
+++ b/installation-and-setup/sso-setup.md
@@ -1,0 +1,97 @@
+---
+title: Single Sign-On (SSO) Setup
+page_title: Single Sign-On (SSO) Setup - Installation | Fiddler Everywhere
+description: "Learn how Fiddler Everywhere Enterprise customers can configure and use SAML-based single sign-on (SSO) for streamlined and secure authentication."
+slug: fe-sso-setup
+position: 45
+---
+
+# Single Sign-On (SSO) Setup
+
+The **Fiddler Everywhere Enterprise** license tier supports **single sign-on (SSO)**, allowing your organization's users to log in to Fiddler Everywhere with their existing identity provider (IdP) credentials instead of a separate Fiddler/Telerik username and password. SSO streamlines authentication and improves security by centralizing access control at the organization level.
+
+>tip The [Fiddler Everywhere Enterprise subscription plan](https://www.telerik.com/purchase/fiddler) is required to enable SSO. For a comparison of the available license tiers, refer to the [Commercial Licenses]({%slug introduction%}#commercial-licenses) section of the Introduction article.
+
+SSO is configured and managed centrally through your Telerik account and applies to all Telerik and Kendo UI products covered by an eligible **DevCraft Complete** or **DevCraft Ultimate** subscription license, including Fiddler Everywhere.
+
+## Available SSO Setup Options
+
+Two options are available for enabling SSO:
+
+* **Self-guided SAML setup (recommended)**&mdash;Configure SSO directly from your Telerik account dashboard using **SAML**. This option currently supports the following identity providers:
+    * Microsoft Entra ID (formerly Azure AD)
+    * AD FS
+    * Okta
+* **Assisted setup for other providers**&mdash;If your organization uses a non-SAML identity provider, the Telerik support team can help you configure SSO through a guided setup process.
+
+## Prerequisites
+
+* An eligible **Fiddler Everywhere Enterprise** license as part of a **DevCraft Complete** or **DevCraft Ultimate** subscription.
+* **License Holder** or **License Manager** permissions for the license in [Your Telerik Account](https://www.telerik.com/account/).
+* Ownership (or IT team access) of the organization's domain to add DNS records for domain verification.
+* Administrative access to the identity provider (Microsoft Entra ID, AD FS, Okta, or other) to register the SAML application.
+
+## Setting Up SAML SSO (Self-Guided)
+
+### Step 1: Configure SSO
+
+1. Log in to [Your Telerik Account](https://www.telerik.com/account/).
+1. If your license is eligible and you are a **License Holder** or **License Manager**, you will see a banner to **Configure SSO**. Alternatively, navigate to **Manage SSO** from your account settings.
+
+### Step 2: Verify Your Domain
+
+To confirm domain ownership:
+
+1. Ask your IT team to add the provided challenge key to your domain's DNS records.
+1. Wait until the key is visible via a DNS lookup.
+1. Click **Verify Domain**.
+
+>tip Domain verification progress is saved automatically, so you can leave and return later to complete the process.
+
+### Step 3: Configure Your Identity Provider
+
+Once the domain is verified:
+
+1. Register the SAML configuration with your identity provider.
+1. Enter the **Metadata URL**.
+1. Map the required claims: email address, first name, and last name.
+1. Verify that all URLs are mapped correctly.
+
+>warning Incorrect claim mappings result in login failures. When using **Okta**, make sure to use **Name attributes** when setting identifiers and claims.
+
+### Step 4: Test and Confirm
+
+Test the login URL to verify that the configuration works. Once successful, you will receive a confirmation message that SSO is active.
+
+>warning Do not skip this step. Only proceed to enabling SSO for a specific license after you see the **SSO Successfully Configured** confirmation message.
+
+### Step 5: Enable SSO
+
+1. Review and confirm that the correct domain is selected for provisioning.
+1. Click **Enable SSO** to start the setup for the selected license.
+1. Click **Apply Changes** to complete the process and enable SSO access for all applicable users associated with the license.
+
+>tip To enable SSO for additional licenses later, return to the **Manage SSO** section in **Your Account** and repeat this step for any new or existing licenses.
+
+## What Happens After SSO Is Enabled
+
+* Only users assigned to the enabled license(s) with email addresses matching the verified domain will log in via SSO exclusively. Even if these users previously logged in to Fiddler Everywhere with a username and password, SSO becomes the only supported authentication method going forward.
+* Affected users receive an email notification with login instructions.
+* If a license expires, users can still sign in via SSO for **10 days**. After that period, they need to recover their password and sign in with a username and password.
+
+You can also automate user access and license assignments through SCIM provisioning. For more information, refer to the [SCIM Provisioning blog post](https://www.telerik.com/blogs/scim-provisioning-telerik-kendo-ui-licenses).
+
+## Considerations
+
+* SSO configuration is managed at the Telerik account level, not from within the Fiddler Everywhere application itself.
+* If your organization also uses the Telerik NuGet server or Visual Studio Extensions (VSX), verify that all affected developers use [Telerik NuGet Keys](https://www.telerik.com/blogs/announcing-nuget-keys) instead of password-based authentication before enabling SSO, since password-based login to the NuGet feed stops working once SSO is enforced.
+* For non-SAML identity providers, contact [Telerik support](https://www.telerik.com/account/support-tickets) to request assisted SSO setup.
+
+## See Also
+
+* [First Steps on Windows]({%slug first_steps_windows%})
+* [First Steps on macOS]({%slug first_steps_macos%})
+* [First Steps on Linux]({%slug first_steps_linux%})
+* [Managed App Configuration]({%slug fe-restrict-policies%})
+* [Security Highlights]({%slug fe-security-highlights%})
+* [SSO Comes to DevCraft Complete and Ultimate Subscription Licenses (Telerik blog)](https://www.telerik.com/blogs/sso-telerik-kendo-ui-simpler-more-secure-access-account)

--- a/security/security-highlights.md
+++ b/security/security-highlights.md
@@ -83,3 +83,9 @@ Fiddler Everywhere provides an [MCP (Model Context Protocol) server]({%slug fidd
 ## SOC Compliance
 
 The Fiddler Everywhere application is certified by an independent third party to comply with the service organization control standards (SOC 2) developed by the Association of International Certified Professional Accountants (AICPA). Compliance with SOC 2 is a testament that Progress has established a comprehensive set of internal procedures and controls to ensure the security, confidentiality, and availability of its cloud services and software development infrastructure, increasing the level of trust and confidence organizations have when choosing to rely on Progress services and products.
+
+## See Also
+
+* [Single Sign-On (SSO) Setup](slug://fe-sso-setup)
+* [Managed App Configuration](slug://fe-restrict-policies)
+* [Applying sanitization for captured traffic in Fiddler Everywhere](slug://fe-sanitization)

--- a/spelling-errors.txt
+++ b/spelling-errors.txt
@@ -1,6 +1,12 @@
 VPN
 TLS
 SSL
+SAML
+Okta
+Entra
+IdP
+DevCraft
+SCIM
 blocklist
 blocklisting
 allowlist


### PR DESCRIPTION
## Summary
Adds a new documentation article explaining how **Fiddler Everywhere Enterprise** customers can configure and use **Single Sign-On (SSO)**, based on the Telerik blog post: [SSO Comes to DevCraft Complete and Ultimate Subscription Licenses](https://www.telerik.com/blogs/sso-telerik-kendo-ui-simpler-more-secure-access-account).

Jira: [FID-8659](https://progresssoftware.atlassian.net/browse/FID-8659)

## Changes
- **New article:** installation-and-setup/sso-setup.md (slug `fe-sso-setup`) covering:
  - SSO availability restricted to the Fiddler Everywhere **Enterprise** tier
  - Self-guided SAML setup (Microsoft Entra ID, AD FS, Okta) vs. assisted setup for other IdPs
  - Prerequisites, step-by-step setup (configure, verify domain, configure IdP, test, enable)
  - Post-enablement behavior (forced SSO login, 10-day grace period after license expiry)
  - SCIM provisioning note and Telerik NuGet/VSX caveat
- Placed under **Installation & Setup** (position 45), alongside the existing account/login quickstart guides and the Enterprise-only *Managed App Configuration* article.
- Updated the Windows/macOS/Linux quickstart guides to link to the new internal article instead of the raw blog URL.
- Added cross-links (`See Also`) between the new article, *Managed App Configuration*, and *Security Highlights*.
- Whitelisted new terminology (`SAML`, `Okta`, `Entra`, `IdP`, `DevCraft`, `SCIM`) in `spelling-errors.txt` for the spell checker.

## Testing
- Documentation-only change; verified frontmatter/slug conventions and internal `slug://`/`{%slug%}` links follow existing patterns used elsewhere in the repo.

[FID-8659]: https://progresssoftware.atlassian.net/browse/FID-8659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ